### PR TITLE
Add dylib to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ build
 release
 debug
 *.so
+*.dylib
 
 # Package
 bun.lockb


### PR DESCRIPTION
Seems that the compiled package under macOS is .dylib suffixed.