### PR TITLE
Add Tests for Tile & Mean

### DIFF
--- a/test/mean.test.ts
+++ b/test/mean.test.ts
@@ -1,0 +1,80 @@
+import { expect, it, describe } from 'bun:test'
+import * as sm from 'shumaiml'
+import { expectArraysClose, isClose, isShape } from './utils'
+
+describe('mean', () => {
+  it('basic', () => {
+    const t = sm
+      .tensor(
+        new Float32Array([
+          0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24,
+          25, 26, 27, 28, 29, 30, 31
+        ])
+      )
+      .reshape([16, 2])
+    const mean = sm.mean(t)
+
+    expect(isClose(<number>mean.valueOf(), 15.5)).toBe(true)
+  })
+
+  it('propagates NaNs', () => {
+    const t = sm.tensor(new Float32Array([1, 2, 3, NaN, 0, 1])).reshape([3, 2])
+    const mean = sm.mean(t)
+    expect(isClose(<number>mean.valueOf(), NaN)).toBe(true)
+  })
+
+  it('works for 1D Tensor', () => {
+    const t = sm.tensor(new Float32Array([3, 1, 5, 2, 4]))
+    const mean = sm.mean(t)
+    expect(isClose(<number>mean.valueOf(), 3)).toBe(true)
+  })
+
+  it('works for 2D Tensor; keep_dims=true', () => {
+    const t = sm.tensor(new Float32Array([1, 2, 3, 0, 0, 1])).reshape([3, 2])
+    const mean = sm.mean(t, [], true)
+    expect(isShape(mean, [1, 1])).toBe(true)
+    expect(isClose(<number>mean.valueOf(), 7 / 6)).toBe(true)
+  })
+
+  /* TODO: FIX - CURRENTLY FAILS */
+  it('2D Tensor; axis=[0]', () => {
+    const t = sm.tensor(new Float32Array([1, 2, 3, 0, 0, 1])).reshape([3, 2])
+    const mean = sm.mean(t, [0])
+    expect(isShape(mean, [2])).toBe(true)
+    expectArraysClose(<Float32Array>mean.valueOf(), [4 / 3, 1])
+  })
+
+  /* TODO: FIX - CURRENTLY FAILS */
+  it('2D Tensor; axis=[0], keep_dims=true', () => {
+    const t = sm.tensor(new Float32Array([1, 2, 3, 0, 0, 1])).reshape([3, 2])
+    const mean = sm.mean(t, [0], true)
+    expect(isShape(mean, [1, 2])).toBe(true)
+    expectArraysClose(<Float32Array>mean.valueOf(), [4 / 3, 1])
+  })
+
+  /* TODO: FIX - CURRENTLY FAILS */
+  it('2D Tensor; axis=[1]', () => {
+    const t = sm.tensor(new Float32Array([1, 2, 3, 0, 0, 1])).reshape([3, 2])
+    const mean = sm.mean(t, [1])
+    expect(isShape(mean, [3])).toBe(true)
+    expectArraysClose(<Float32Array>mean.valueOf(), [1.5, 1.5, 0.5])
+  })
+
+  /* TODO: FIX - CURRENTLY FAILS */
+  it('2D Tensor; axis=[-1]', () => {
+    const t = sm.tensor(new Float32Array([1, 2, 3, 0, 0, 1])).reshape([3, 2])
+    const mean = sm.mean(t, [-1])
+    expect(isShape(mean, [3])).toBe(true)
+    expectArraysClose(<Float32Array>mean.valueOf(), [1.5, 1.5, 0.5])
+  })
+
+  /* TODO: FIX - CURRENTLY FAILS */
+  it('2D Tensor; axis=[0,1]', () => {
+    const t = sm.tensor(new Float32Array([1, 2, 3, 0, 0, 1])).reshape([3, 2])
+    const mean = sm.mean(t, [0, 1])
+    expect(isShape(mean, [])).toBe(true)
+    expectArraysClose(<Float32Array>mean.valueOf(), [7 / 6])
+  })
+
+  /* TODO: unit tests for gradients once supported */
+})

--- a/test/tile.test.ts
+++ b/test/tile.test.ts
@@ -1,0 +1,81 @@
+import { it, describe, expect } from 'bun:test'
+import * as sm from 'shumaiml'
+import { expectArraysClose, isShape } from './utils'
+
+describe('tile', () => {
+  it('1D Tensor', () => {
+    const t = sm.tensor(new Float32Array([1, 2, 3]))
+    const t2 = sm.tile(t, [2])
+    expect(isShape(t2, [6])).toBe(true)
+    expectArraysClose(<Float32Array>t2.valueOf(), [1, 2, 3, 1, 2, 3])
+  })
+
+  /* TODO: FIX - CURRENTLY FAILS */
+  it('2D Tensor', () => {
+    const t = sm.tensor(new Float32Array([1, 11, 2, 22])).reshape([2, 2])
+    let t2 = sm.tile(t, [1, 2])
+    expect(isShape(t2, [2, 4])).toBe(true)
+    expectArraysClose(<Float32Array>t2.valueOf(), [1, 11, 1, 11, 2, 22, 2, 22])
+
+    t2 = sm.tile(t, [2, 1])
+    expect(isShape(t2, [4, 2])).toBe(true)
+    expectArraysClose(<Float32Array>t2.valueOf(), [1, 11, 2, 22, 1, 11, 2, 22])
+
+    t2 = sm.tile(t, [2, 2])
+    expect(isShape(t2, [4, 4])).toBe(true)
+    expectArraysClose(
+      <Float32Array>t2.valueOf(),
+      [1, 11, 1, 11, 2, 22, 2, 22, 1, 11, 1, 11, 2, 22, 2, 22]
+    )
+  })
+
+  it('3D Tensor', () => {
+    const t = sm.tensor(new Float32Array([1, 2, 3, 4, 5, 6, 7, 8])).reshape([2, 2, 2])
+    const t2 = sm.tile(t, [1, 2, 1])
+    expect(isShape(t2, [2, 4, 2])).toBe(true)
+    expectArraysClose(<Float32Array>t2.valueOf(), [1, 2, 3, 4, 1, 2, 3, 4, 5, 6, 7, 8, 5, 6, 7, 8])
+  })
+
+  /* TODO: FIX - CURRENTLY FAILS */
+  it('4D Tensor', () => {
+    const t = sm.tensor(new Float32Array([1, 2, 3, 4, 5, 6, 7, 8])).reshape([1, 2, 2, 2])
+    const t2 = sm.tile(t, [1, 2, 1, 1])
+    expect(isShape(t2, [1, 4, 2, 2])).toBe(true)
+    expectArraysClose(<Float32Array>t2.valueOf(), [1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8])
+  })
+
+  /* TODO: FIX - CURRENTLY FAILS (Throws C++ Exception)
+    it('5D Tensor', () => {
+      const t = sm.tensor(new Float32Array([1, 2, 3, 4, 5, 6, 7, 8])).reshape([1, 1, 2, 2, 2])
+      const t2 = sm.tile(t, [1, 2, 1, 1, 1])
+      expect(isShape(t2, [1, 2, 2, 2, 2])).toBe(true)
+      expectArraysClose(<Float32Array>t2.valueOf(), [1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8])
+    })
+  */
+
+  /* TODO: FIX - CURRENTLY FAILS (Throws C++ Exception)
+    it('6D Tensor', () => {
+      const t = sm
+        .tensor(new Float32Array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]))
+        .reshape([1, 1, 2, 2, 2, 2])
+      const t2 = sm.tile(t, [1, 2, 1, 1, 1, 1])
+      expect(isShape(t2, [1, 2, 2, 2, 2, 2])).toBe(true)
+      expectArraysClose(
+        <Float32Array>t2.valueOf(),
+        [
+          1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11,
+          12, 13, 14, 15, 16
+        ]
+      )
+    })
+  */
+
+  it('propagates NaNs', () => {
+    const t = sm.tensor(new Float32Array([1, 2, NaN]))
+    const t2 = sm.tile(t, [2])
+    expect(isShape(t2, [6])).toBe(true)
+    expectArraysClose(<Float32Array>t2.valueOf(), [1, 2, NaN, 1, 2, NaN])
+  })
+
+  /* TODO: unit tests for gradients once supported */
+})

--- a/test/transpose.test.ts
+++ b/test/transpose.test.ts
@@ -11,7 +11,7 @@ describe('transpose', () => {
   })
 
   /* TODO: FIX - CURRENTLY FAILS */
-  it('2D (transpose)', () => {
+  it('2D Tensor', () => {
     const t = sm.tensor(new Float32Array([1, 11, 2, 22, 3, 33, 4, 44])).reshape([2, 4])
     t.transpose([1, 0])
     expect(isShape(t, [4, 2])).toBe(true)


### PR DESCRIPTION
Suspect the newly added failing tests are a result of the current default to column major (whereas TFJS API defaults to Row Major for Tensor Operations). Per conversation with @bwasti, I'd suggest we imitate TFJS in defaulting to Row Major to enable developer's familiar with Tensorflow.js to explore the API/migrate their codebase.