### PR TITLE
Add `eval()` semantics to JS, for performance

### DIFF
--- a/examples/train.js
+++ b/examples/train.js
@@ -54,6 +54,7 @@ const optimize = (...args) => {
       const t = l[key]
       if (t.constructor === sm.Tensor && t.requires_grad) {
         l[key] = upd(t)
+        l[key].eval()
       }
     }
   }
@@ -62,7 +63,7 @@ const optimize = (...args) => {
   }
 }
 
-const show_timing = true
+const show_timing = false
 const traint0 = performance.now()
 let floss = 0
 for (let i = 0; i < 1000; ++i) {

--- a/src/cpp/flashlight_binding.cc
+++ b/src/cpp/flashlight_binding.cc
@@ -1,6 +1,7 @@
 #include "flashlight/fl/nn/Init.h"
 #include "flashlight/fl/runtime/Device.h"
 #include "flashlight/fl/runtime/Stream.h"
+#include "flashlight/fl/tensor/Compute.h"
 #include "flashlight/fl/tensor/Index.h"
 #include "flashlight/fl/tensor/Init.h"
 #include "flashlight/fl/tensor/Random.h"
@@ -53,6 +54,11 @@ typedef void (*JSTypedArrayBytesDeallocator)(void *bytes,
                                              void *deallocatorContext);
 
 JSTypedArrayBytesDeallocator genTensorDestroyer() { return destroyTensor; }
+
+void eval(void *t) {
+  auto *tensor = reinterpret_cast<fl::Tensor *>(t);
+  fl::eval(*tensor);
+}
 
 size_t elements(void *t) {
   auto *tensor = reinterpret_cast<fl::Tensor *>(t);

--- a/src/ffi/ffi_flashlight.ts
+++ b/src/ffi/ffi_flashlight.ts
@@ -16,7 +16,7 @@ const { symbols: fl } = (() => {
       ...ffi_tensor_ops
     })
   } catch (error) {
-    console.error("Bun trace:", error)
+    console.error('Bun trace:', error)
     throw new Error(`shumai was unable to load backing libraries!
     Make sure a valid tensor backend (e.g. ArrayFire) is installed by running,
     for example:
@@ -30,7 +30,7 @@ const { symbols: fl } = (() => {
     If you're still having trouble, please create an issue
     (https://github.com/facebookresearch/shumai/issues)
     outlining your system and platform details.
-    `);
+    `)
   }
 })()
 

--- a/src/ffi/ffi_tensor.ts
+++ b/src/ffi/ffi_tensor.ts
@@ -19,6 +19,9 @@ const ffi_tensor = {
     args: [FFIType.i32, FFIType.ptr],
     returns: FFIType.ptr
   },
+  eval: {
+    args: [FFIType.ptr]
+  },
   buffer: {
     args: [FFIType.ptr],
     returns: FFIType.ptr

--- a/src/tensor/tensor.ts
+++ b/src/tensor/tensor.ts
@@ -158,6 +158,10 @@ class Tensor {
     return
   }
 
+  eval() {
+    return fl.eval.native(this.ptr)
+  }
+
   get ptr() {
     return ptr(this.underlying)
   }


### PR DESCRIPTION
Thanks Jacob for recommending this!

By exposing eval, we can control when the JIT (and future JITs) executes.

In train.js, before eval:
<img width="344" alt="Screen Shot 2022-09-01 at 9 00 53 PM" src="https://user-images.githubusercontent.com/4842908/188037193-4d7e0faa-6772-4d6b-ad0e-536f0d52d0c5.png">

After eval:
<img width="346" alt="Screen Shot 2022-09-01 at 9 00 50 PM" src="https://user-images.githubusercontent.com/4842908/188037214-2bc76742-b37f-4f8a-90bb-a91307c9e175.png">

