### PR TITLE
Fix types in tensor_ops_shim_gen.ts & general cleanup

### DIFF
--- a/examples/bench.ts
+++ b/examples/bench.ts
@@ -10,9 +10,9 @@ function bench(description, f, iters = 1000) {
   }
   const t = new Tensor(hist)
   console.log(
-    `${description} \t mean: ${Math.round(t.mean()) / 1e3}us    (min: ${
-      Math.round(t.amin()) / 1e3
-    }us, max: ${Math.round(t.amax()) / 1e3}us)`
+    `${description} \t mean: ${Math.round(t.mean().toFloat32()) / 1e3}us    (min: ${
+      Math.round(t.amin().toFloat32()) / 1e3
+    }us, max: ${Math.round(t.amax().toFloat32()) / 1e3}us)`
   )
 }
 
@@ -20,9 +20,11 @@ for (const N of [10, 1000, 100000]) {
   console.log(`${N} elements...`)
   bench(`JS create 0 tensor     `, () => {
     const a = new Float32Array(N)
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const t = new Tensor(a)
   })
   bench(`native create 0 tensor `, () => {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const t = new Tensor(N)
   })
   bench(`JS create random tensor`, () => {
@@ -30,9 +32,11 @@ for (const N of [10, 1000, 100000]) {
     for (let i = 0; i < N; ++i) {
       a[i] = Math.random()
     }
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const t = new Tensor(a)
   })
   bench(`native create random tensor`, () => {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const t = rand([N])
   })
 }

--- a/package.json
+++ b/package.json
@@ -4,11 +4,10 @@
   "module": "shumai/index.ts",
   "type": "module",
   "scripts": {
-    "format": "eslint '*/**/*.{js,ts}' '*.{js,ts,cjs}' package.json  --quiet --fix"
+    "format": "eslint '**/*.{js,ts}' '*.{js,ts,cjs}' package.json --fix"
   },
   "files": [
-    "shumai/*/**.ts",
-    "shumai/*.ts"
+    "shumai/**/*.ts"
   ],
   "keywords": [
     "bun",
@@ -21,14 +20,14 @@
     "ai"
   ],
   "devDependencies": {
-    "@typescript-eslint/eslint-plugin": "^5.35.1",
+    "@typescript-eslint/eslint-plugin": "^5.36.2",
     "@typescript-eslint/parser": "^5.35.1",
-    "bun-types": "^0.1.0",
+    "bun-types": "^0.1.11",
     "eslint": "^8.23.0",
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-prettier": "^4.2.1",
     "prettier": "^2.7.1",
-    "typescript": "^4.8.2"
+    "typescript": "^4.8.3"
   },
   "optionalDependencies": {
     "@shumai/darwin_arm64_shumai_flashlight": "latest",

--- a/python_comparison/ffi.ts
+++ b/python_comparison/ffi.ts
@@ -23,7 +23,8 @@ function noop() {
 }
 
 function wrapped_noop() {
-  const f = (x) => {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const f = (_x: number) => {
     lib.no_op()
   }
   const N = 1e8

--- a/python_comparison/fib.ts
+++ b/python_comparison/fib.ts
@@ -6,6 +6,8 @@ const fib = (n: number): number => {
 }
 
 const N = 35
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const out = fib(N)
 
 console.log((performance.now() - t0) / 1e3, 'seconds')

--- a/python_comparison/file.ts
+++ b/python_comparison/file.ts
@@ -1,4 +1,4 @@
-import fs from 'node:fs'
+import * as fs from 'node:fs'
 
 const t0 = performance.now()
 fs.readFile('input.txt', 'utf8', function (err, data) {

--- a/python_comparison/number.ts
+++ b/python_comparison/number.ts
@@ -12,6 +12,7 @@ for (let i = 1; i < arr.length; ++i) {
 }
 let total = 0
 for (let i = 0; i < arr.length; ++i) {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   total += arr[i]
 }
 console.log((performance.now() - t0) / 1e3, 'seconds')

--- a/scripts/gen_binding.py
+++ b/scripts/gen_binding.py
@@ -411,7 +411,7 @@ import {{ arrayArg }} from '../ffi/ffi_bind_utils'
 import {{ fl }} from '../ffi/ffi_flashlight'
 import {{ TensorInterface }} from './tensor_interface'
 import type {{ Tensor }} from './tensor'
-export const gen_tensor_op_shim = (_Tensor: (...args: any[]) => Tensor) => {{
+export const gen_tensor_op_shim = (_Tensor: new (...args: unknown[]) => Tensor) => {{
   return {{{full_js}
   }};
 }}

--- a/shumai/cpp/binding_gen.inl
+++ b/shumai/cpp/binding_gen.inl
@@ -1,566 +1,549 @@
 
-void *_rand(void *shape_ptr, int64_t shape_len) {
+void* _rand(void *shape_ptr, int64_t shape_len) {
   auto shape = arrayArg<long long>(shape_ptr, shape_len, g_row_major, false);
-  auto *t = new fl::Tensor(fl::rand(fl::Shape(shape)));
+  auto* t = new fl::Tensor(fl::rand(fl::Shape(shape)));
   g_bytes_used += t->bytes();
   return t;
 }
 
-void *_randn(void *shape_ptr, int64_t shape_len) {
+void* _randn(void *shape_ptr, int64_t shape_len) {
   auto shape = arrayArg<long long>(shape_ptr, shape_len, g_row_major, false);
-  auto *t = new fl::Tensor(fl::randn(fl::Shape(shape)));
+  auto* t = new fl::Tensor(fl::randn(fl::Shape(shape)));
   g_bytes_used += t->bytes();
   return t;
 }
 
-void *_full(void *shape_ptr, int64_t shape_len, float val) {
+void* _full(void *shape_ptr, int64_t shape_len, float val) {
   auto shape = arrayArg<long long>(shape_ptr, shape_len, g_row_major, false);
-  auto *t = new fl::Tensor(fl::full(fl::Shape(shape), val));
+  auto* t = new fl::Tensor(fl::full(fl::Shape(shape), val));
   g_bytes_used += t->bytes();
   return t;
 }
 
-void *_identity(int64_t dim) {
-  auto *t = new fl::Tensor(fl::identity(dim));
+void* _identity(int64_t dim) {
+  auto* t = new fl::Tensor(fl::identity(dim));
   g_bytes_used += t->bytes();
   return t;
 }
 
-void *_arange(float start, float end, float step) {
-  auto *t = new fl::Tensor(fl::arange(start, end, step));
+void* _arange(float start, float end, float step) {
+  auto* t = new fl::Tensor(fl::arange(start, end, step));
   g_bytes_used += t->bytes();
   return t;
 }
 
-void *_iota(void *dims_ptr, int64_t dims_len, void *tileDims_ptr,
-            int64_t tileDims_len) {
+void* _iota(void *dims_ptr, int64_t dims_len, void *tileDims_ptr, int64_t tileDims_len) {
   auto dims = arrayArg<long long>(dims_ptr, dims_len, g_row_major, false);
-  auto tileDims =
-      arrayArg<long long>(tileDims_ptr, tileDims_len, g_row_major, false);
-  auto *t = new fl::Tensor(fl::iota(fl::Shape(dims), fl::Shape(tileDims)));
+  auto tileDims = arrayArg<long long>(tileDims_ptr, tileDims_len, g_row_major, false);
+  auto* t = new fl::Tensor(fl::iota(fl::Shape(dims), fl::Shape(tileDims)));
   g_bytes_used += t->bytes();
   return t;
 }
 
-void *_reshape(void *tensor, void *shape_ptr, int64_t shape_len) {
-  auto *tensor_ptr = reinterpret_cast<fl::Tensor *>(tensor);
+void* _reshape(void *tensor, void *shape_ptr, int64_t shape_len) {
+  auto *tensor_ptr = reinterpret_cast<fl::Tensor*>(tensor);
   auto shape = arrayArg<long long>(shape_ptr, shape_len, g_row_major, false);
-  auto *t = new fl::Tensor(fl::reshape(*tensor_ptr, fl::Shape(shape)));
+  auto* t = new fl::Tensor(fl::reshape(*tensor_ptr, fl::Shape(shape)));
   g_bytes_used += t->bytes();
   return t;
 }
 
-void *_transpose(void *tensor, void *axes_ptr, int64_t axes_len) {
-  auto *tensor_ptr = reinterpret_cast<fl::Tensor *>(tensor);
-  auto axes =
-      arrayArg<long long>(axes_ptr, axes_len, g_row_major, tensor_ptr->ndim());
-  auto *t = new fl::Tensor(fl::transpose(*tensor_ptr, fl::Shape(axes)));
+void* _transpose(void *tensor, void *axes_ptr, int64_t axes_len) {
+  auto *tensor_ptr = reinterpret_cast<fl::Tensor*>(tensor);
+  auto axes = arrayArg<long long>(axes_ptr, axes_len, g_row_major, tensor_ptr->ndim());
+  auto* t = new fl::Tensor(fl::transpose(*tensor_ptr, fl::Shape(axes)));
   g_bytes_used += t->bytes();
   return t;
 }
 
-void *_tile(void *tensor, void *shape_ptr, int64_t shape_len) {
-  auto *tensor_ptr = reinterpret_cast<fl::Tensor *>(tensor);
+void* _tile(void *tensor, void *shape_ptr, int64_t shape_len) {
+  auto *tensor_ptr = reinterpret_cast<fl::Tensor*>(tensor);
   auto shape = arrayArg<long long>(shape_ptr, shape_len, g_row_major, false);
-  auto *t = new fl::Tensor(fl::tile(*tensor_ptr, fl::Shape(shape)));
+  auto* t = new fl::Tensor(fl::tile(*tensor_ptr, fl::Shape(shape)));
   g_bytes_used += t->bytes();
   return t;
 }
 
-void *_nonzero(void *tensor) {
-  auto *tensor_ptr = reinterpret_cast<fl::Tensor *>(tensor);
-  auto *t = new fl::Tensor(fl::nonzero(*tensor_ptr));
+void* _nonzero(void *tensor) {
+  auto *tensor_ptr = reinterpret_cast<fl::Tensor*>(tensor);
+  auto* t = new fl::Tensor(fl::nonzero(*tensor_ptr));
   g_bytes_used += t->bytes();
   return t;
 }
 
-void *_negative(void *tensor) {
-  auto *tensor_ptr = reinterpret_cast<fl::Tensor *>(tensor);
-  auto *t = new fl::Tensor(fl::negative(*tensor_ptr));
+void* _negative(void *tensor) {
+  auto *tensor_ptr = reinterpret_cast<fl::Tensor*>(tensor);
+  auto* t = new fl::Tensor(fl::negative(*tensor_ptr));
   g_bytes_used += t->bytes();
   return t;
 }
 
-void *_logicalNot(void *tensor) {
-  auto *tensor_ptr = reinterpret_cast<fl::Tensor *>(tensor);
-  auto *t = new fl::Tensor(fl::logicalNot(*tensor_ptr));
+void* _logicalNot(void *tensor) {
+  auto *tensor_ptr = reinterpret_cast<fl::Tensor*>(tensor);
+  auto* t = new fl::Tensor(fl::logicalNot(*tensor_ptr));
   g_bytes_used += t->bytes();
   return t;
 }
 
-void *_exp(void *tensor) {
-  auto *tensor_ptr = reinterpret_cast<fl::Tensor *>(tensor);
-  auto *t = new fl::Tensor(fl::exp(*tensor_ptr));
+void* _exp(void *tensor) {
+  auto *tensor_ptr = reinterpret_cast<fl::Tensor*>(tensor);
+  auto* t = new fl::Tensor(fl::exp(*tensor_ptr));
   g_bytes_used += t->bytes();
   return t;
 }
 
-void *_log(void *tensor) {
-  auto *tensor_ptr = reinterpret_cast<fl::Tensor *>(tensor);
-  auto *t = new fl::Tensor(fl::log(*tensor_ptr));
+void* _log(void *tensor) {
+  auto *tensor_ptr = reinterpret_cast<fl::Tensor*>(tensor);
+  auto* t = new fl::Tensor(fl::log(*tensor_ptr));
   g_bytes_used += t->bytes();
   return t;
 }
 
-void *_log1p(void *tensor) {
-  auto *tensor_ptr = reinterpret_cast<fl::Tensor *>(tensor);
-  auto *t = new fl::Tensor(fl::log1p(*tensor_ptr));
+void* _log1p(void *tensor) {
+  auto *tensor_ptr = reinterpret_cast<fl::Tensor*>(tensor);
+  auto* t = new fl::Tensor(fl::log1p(*tensor_ptr));
   g_bytes_used += t->bytes();
   return t;
 }
 
-void *_sin(void *tensor) {
-  auto *tensor_ptr = reinterpret_cast<fl::Tensor *>(tensor);
-  auto *t = new fl::Tensor(fl::sin(*tensor_ptr));
+void* _sin(void *tensor) {
+  auto *tensor_ptr = reinterpret_cast<fl::Tensor*>(tensor);
+  auto* t = new fl::Tensor(fl::sin(*tensor_ptr));
   g_bytes_used += t->bytes();
   return t;
 }
 
-void *_cos(void *tensor) {
-  auto *tensor_ptr = reinterpret_cast<fl::Tensor *>(tensor);
-  auto *t = new fl::Tensor(fl::cos(*tensor_ptr));
+void* _cos(void *tensor) {
+  auto *tensor_ptr = reinterpret_cast<fl::Tensor*>(tensor);
+  auto* t = new fl::Tensor(fl::cos(*tensor_ptr));
   g_bytes_used += t->bytes();
   return t;
 }
 
-void *_sqrt(void *tensor) {
-  auto *tensor_ptr = reinterpret_cast<fl::Tensor *>(tensor);
-  auto *t = new fl::Tensor(fl::sqrt(*tensor_ptr));
+void* _sqrt(void *tensor) {
+  auto *tensor_ptr = reinterpret_cast<fl::Tensor*>(tensor);
+  auto* t = new fl::Tensor(fl::sqrt(*tensor_ptr));
   g_bytes_used += t->bytes();
   return t;
 }
 
-void *_tanh(void *tensor) {
-  auto *tensor_ptr = reinterpret_cast<fl::Tensor *>(tensor);
-  auto *t = new fl::Tensor(fl::tanh(*tensor_ptr));
+void* _tanh(void *tensor) {
+  auto *tensor_ptr = reinterpret_cast<fl::Tensor*>(tensor);
+  auto* t = new fl::Tensor(fl::tanh(*tensor_ptr));
   g_bytes_used += t->bytes();
   return t;
 }
 
-void *_floor(void *tensor) {
-  auto *tensor_ptr = reinterpret_cast<fl::Tensor *>(tensor);
-  auto *t = new fl::Tensor(fl::floor(*tensor_ptr));
+void* _floor(void *tensor) {
+  auto *tensor_ptr = reinterpret_cast<fl::Tensor*>(tensor);
+  auto* t = new fl::Tensor(fl::floor(*tensor_ptr));
   g_bytes_used += t->bytes();
   return t;
 }
 
-void *_ceil(void *tensor) {
-  auto *tensor_ptr = reinterpret_cast<fl::Tensor *>(tensor);
-  auto *t = new fl::Tensor(fl::ceil(*tensor_ptr));
+void* _ceil(void *tensor) {
+  auto *tensor_ptr = reinterpret_cast<fl::Tensor*>(tensor);
+  auto* t = new fl::Tensor(fl::ceil(*tensor_ptr));
   g_bytes_used += t->bytes();
   return t;
 }
 
-void *_rint(void *tensor) {
-  auto *tensor_ptr = reinterpret_cast<fl::Tensor *>(tensor);
-  auto *t = new fl::Tensor(fl::rint(*tensor_ptr));
+void* _rint(void *tensor) {
+  auto *tensor_ptr = reinterpret_cast<fl::Tensor*>(tensor);
+  auto* t = new fl::Tensor(fl::rint(*tensor_ptr));
   g_bytes_used += t->bytes();
   return t;
 }
 
-void *_absolute(void *tensor) {
-  auto *tensor_ptr = reinterpret_cast<fl::Tensor *>(tensor);
-  auto *t = new fl::Tensor(fl::absolute(*tensor_ptr));
+void* _absolute(void *tensor) {
+  auto *tensor_ptr = reinterpret_cast<fl::Tensor*>(tensor);
+  auto* t = new fl::Tensor(fl::absolute(*tensor_ptr));
   g_bytes_used += t->bytes();
   return t;
 }
 
-void *_abs(void *tensor) {
-  auto *tensor_ptr = reinterpret_cast<fl::Tensor *>(tensor);
-  auto *t = new fl::Tensor(fl::abs(*tensor_ptr));
+void* _abs(void *tensor) {
+  auto *tensor_ptr = reinterpret_cast<fl::Tensor*>(tensor);
+  auto* t = new fl::Tensor(fl::abs(*tensor_ptr));
   g_bytes_used += t->bytes();
   return t;
 }
 
-void *_sigmoid(void *tensor) {
-  auto *tensor_ptr = reinterpret_cast<fl::Tensor *>(tensor);
-  auto *t = new fl::Tensor(fl::sigmoid(*tensor_ptr));
+void* _sigmoid(void *tensor) {
+  auto *tensor_ptr = reinterpret_cast<fl::Tensor*>(tensor);
+  auto* t = new fl::Tensor(fl::sigmoid(*tensor_ptr));
   g_bytes_used += t->bytes();
   return t;
 }
 
-void *_erf(void *tensor) {
-  auto *tensor_ptr = reinterpret_cast<fl::Tensor *>(tensor);
-  auto *t = new fl::Tensor(fl::erf(*tensor_ptr));
+void* _erf(void *tensor) {
+  auto *tensor_ptr = reinterpret_cast<fl::Tensor*>(tensor);
+  auto* t = new fl::Tensor(fl::erf(*tensor_ptr));
   g_bytes_used += t->bytes();
   return t;
 }
 
-void *_flip(void *tensor, uint32_t dim) {
-  auto *tensor_ptr = reinterpret_cast<fl::Tensor *>(tensor);
-  auto *t = new fl::Tensor(fl::flip(*tensor_ptr, dim));
+void* _flip(void *tensor, uint32_t dim) {
+  auto *tensor_ptr = reinterpret_cast<fl::Tensor*>(tensor);
+  auto* t = new fl::Tensor(fl::flip(*tensor_ptr, dim));
   g_bytes_used += t->bytes();
   return t;
 }
 
-void *_clip(void *tensor, void *low, void *high) {
-  auto *tensor_ptr = reinterpret_cast<fl::Tensor *>(tensor);
-  auto *low_ptr = reinterpret_cast<fl::Tensor *>(low);
-  auto *high_ptr = reinterpret_cast<fl::Tensor *>(high);
-  auto *t = new fl::Tensor(fl::clip(*tensor_ptr, *low_ptr, *high_ptr));
+void* _clip(void *tensor, void *low, void *high) {
+  auto *tensor_ptr = reinterpret_cast<fl::Tensor*>(tensor);
+  auto *low_ptr = reinterpret_cast<fl::Tensor*>(low);
+  auto *high_ptr = reinterpret_cast<fl::Tensor*>(high);
+  auto* t = new fl::Tensor(fl::clip(*tensor_ptr, *low_ptr, *high_ptr));
   g_bytes_used += t->bytes();
   return t;
 }
 
-void *_roll(void *tensor, int shift, uint32_t axis) {
-  auto *tensor_ptr = reinterpret_cast<fl::Tensor *>(tensor);
-  auto *t = new fl::Tensor(fl::roll(*tensor_ptr, shift, axis));
+void* _roll(void *tensor, int shift, uint32_t axis) {
+  auto *tensor_ptr = reinterpret_cast<fl::Tensor*>(tensor);
+  auto* t = new fl::Tensor(fl::roll(*tensor_ptr, shift, axis));
   g_bytes_used += t->bytes();
   return t;
 }
 
-void *_isnan(void *tensor) {
-  auto *tensor_ptr = reinterpret_cast<fl::Tensor *>(tensor);
-  auto *t = new fl::Tensor(fl::isnan(*tensor_ptr));
+void* _isnan(void *tensor) {
+  auto *tensor_ptr = reinterpret_cast<fl::Tensor*>(tensor);
+  auto* t = new fl::Tensor(fl::isnan(*tensor_ptr));
   g_bytes_used += t->bytes();
   return t;
 }
 
-void *_isinf(void *tensor) {
-  auto *tensor_ptr = reinterpret_cast<fl::Tensor *>(tensor);
-  auto *t = new fl::Tensor(fl::isinf(*tensor_ptr));
+void* _isinf(void *tensor) {
+  auto *tensor_ptr = reinterpret_cast<fl::Tensor*>(tensor);
+  auto* t = new fl::Tensor(fl::isinf(*tensor_ptr));
   g_bytes_used += t->bytes();
   return t;
 }
 
-void *_sign(void *tensor) {
-  auto *tensor_ptr = reinterpret_cast<fl::Tensor *>(tensor);
-  auto *t = new fl::Tensor(fl::sign(*tensor_ptr));
+void* _sign(void *tensor) {
+  auto *tensor_ptr = reinterpret_cast<fl::Tensor*>(tensor);
+  auto* t = new fl::Tensor(fl::sign(*tensor_ptr));
   g_bytes_used += t->bytes();
   return t;
 }
 
-void *_tril(void *tensor) {
-  auto *tensor_ptr = reinterpret_cast<fl::Tensor *>(tensor);
-  auto *t = new fl::Tensor(fl::tril(*tensor_ptr));
+void* _tril(void *tensor) {
+  auto *tensor_ptr = reinterpret_cast<fl::Tensor*>(tensor);
+  auto* t = new fl::Tensor(fl::tril(*tensor_ptr));
   g_bytes_used += t->bytes();
   return t;
 }
 
-void *_triu(void *tensor) {
-  auto *tensor_ptr = reinterpret_cast<fl::Tensor *>(tensor);
-  auto *t = new fl::Tensor(fl::triu(*tensor_ptr));
+void* _triu(void *tensor) {
+  auto *tensor_ptr = reinterpret_cast<fl::Tensor*>(tensor);
+  auto* t = new fl::Tensor(fl::triu(*tensor_ptr));
   g_bytes_used += t->bytes();
   return t;
 }
 
-void *_where(void *cond, void *x, void *y) {
-  auto *cond_ptr = reinterpret_cast<fl::Tensor *>(cond);
-  auto *x_ptr = reinterpret_cast<fl::Tensor *>(x);
-  auto *y_ptr = reinterpret_cast<fl::Tensor *>(y);
-  auto *t = new fl::Tensor(fl::where(*cond_ptr, *x_ptr, *y_ptr));
+void* _where(void *cond, void *x, void *y) {
+  auto *cond_ptr = reinterpret_cast<fl::Tensor*>(cond);
+  auto *x_ptr = reinterpret_cast<fl::Tensor*>(x);
+  auto *y_ptr = reinterpret_cast<fl::Tensor*>(y);
+  auto* t = new fl::Tensor(fl::where(*cond_ptr, *x_ptr, *y_ptr));
   g_bytes_used += t->bytes();
   return t;
 }
 
-void *_sort(void *tensor, uint32_t dim) {
-  auto *tensor_ptr = reinterpret_cast<fl::Tensor *>(tensor);
-  auto *t = new fl::Tensor(fl::sort(*tensor_ptr, dim));
+void* _sort(void *tensor, uint32_t dim) {
+  auto *tensor_ptr = reinterpret_cast<fl::Tensor*>(tensor);
+  auto* t = new fl::Tensor(fl::sort(*tensor_ptr, dim));
   g_bytes_used += t->bytes();
   return t;
 }
 
-void *_add(void *tensor, void *other) {
-  auto *tensor_ptr = reinterpret_cast<fl::Tensor *>(tensor);
-  auto *other_ptr = reinterpret_cast<fl::Tensor *>(other);
-  auto *t = new fl::Tensor(fl::add(*tensor_ptr, *other_ptr));
+void* _add(void *tensor, void *other) {
+  auto *tensor_ptr = reinterpret_cast<fl::Tensor*>(tensor);
+  auto *other_ptr = reinterpret_cast<fl::Tensor*>(other);
+  auto* t = new fl::Tensor(fl::add(*tensor_ptr, *other_ptr));
   g_bytes_used += t->bytes();
   return t;
 }
 
-void *_sub(void *tensor, void *other) {
-  auto *tensor_ptr = reinterpret_cast<fl::Tensor *>(tensor);
-  auto *other_ptr = reinterpret_cast<fl::Tensor *>(other);
-  auto *t = new fl::Tensor(fl::sub(*tensor_ptr, *other_ptr));
+void* _sub(void *tensor, void *other) {
+  auto *tensor_ptr = reinterpret_cast<fl::Tensor*>(tensor);
+  auto *other_ptr = reinterpret_cast<fl::Tensor*>(other);
+  auto* t = new fl::Tensor(fl::sub(*tensor_ptr, *other_ptr));
   g_bytes_used += t->bytes();
   return t;
 }
 
-void *_mul(void *tensor, void *other) {
-  auto *tensor_ptr = reinterpret_cast<fl::Tensor *>(tensor);
-  auto *other_ptr = reinterpret_cast<fl::Tensor *>(other);
-  auto *t = new fl::Tensor(fl::mul(*tensor_ptr, *other_ptr));
+void* _mul(void *tensor, void *other) {
+  auto *tensor_ptr = reinterpret_cast<fl::Tensor*>(tensor);
+  auto *other_ptr = reinterpret_cast<fl::Tensor*>(other);
+  auto* t = new fl::Tensor(fl::mul(*tensor_ptr, *other_ptr));
   g_bytes_used += t->bytes();
   return t;
 }
 
-void *_div(void *tensor, void *other) {
-  auto *tensor_ptr = reinterpret_cast<fl::Tensor *>(tensor);
-  auto *other_ptr = reinterpret_cast<fl::Tensor *>(other);
-  auto *t = new fl::Tensor(fl::div(*tensor_ptr, *other_ptr));
+void* _div(void *tensor, void *other) {
+  auto *tensor_ptr = reinterpret_cast<fl::Tensor*>(tensor);
+  auto *other_ptr = reinterpret_cast<fl::Tensor*>(other);
+  auto* t = new fl::Tensor(fl::div(*tensor_ptr, *other_ptr));
   g_bytes_used += t->bytes();
   return t;
 }
 
-void *_eq(void *tensor, void *other) {
-  auto *tensor_ptr = reinterpret_cast<fl::Tensor *>(tensor);
-  auto *other_ptr = reinterpret_cast<fl::Tensor *>(other);
-  auto *t = new fl::Tensor(fl::eq(*tensor_ptr, *other_ptr));
+void* _eq(void *tensor, void *other) {
+  auto *tensor_ptr = reinterpret_cast<fl::Tensor*>(tensor);
+  auto *other_ptr = reinterpret_cast<fl::Tensor*>(other);
+  auto* t = new fl::Tensor(fl::eq(*tensor_ptr, *other_ptr));
   g_bytes_used += t->bytes();
   return t;
 }
 
-void *_neq(void *tensor, void *other) {
-  auto *tensor_ptr = reinterpret_cast<fl::Tensor *>(tensor);
-  auto *other_ptr = reinterpret_cast<fl::Tensor *>(other);
-  auto *t = new fl::Tensor(fl::neq(*tensor_ptr, *other_ptr));
+void* _neq(void *tensor, void *other) {
+  auto *tensor_ptr = reinterpret_cast<fl::Tensor*>(tensor);
+  auto *other_ptr = reinterpret_cast<fl::Tensor*>(other);
+  auto* t = new fl::Tensor(fl::neq(*tensor_ptr, *other_ptr));
   g_bytes_used += t->bytes();
   return t;
 }
 
-void *_lessThan(void *tensor, void *other) {
-  auto *tensor_ptr = reinterpret_cast<fl::Tensor *>(tensor);
-  auto *other_ptr = reinterpret_cast<fl::Tensor *>(other);
-  auto *t = new fl::Tensor(fl::lessThan(*tensor_ptr, *other_ptr));
+void* _lessThan(void *tensor, void *other) {
+  auto *tensor_ptr = reinterpret_cast<fl::Tensor*>(tensor);
+  auto *other_ptr = reinterpret_cast<fl::Tensor*>(other);
+  auto* t = new fl::Tensor(fl::lessThan(*tensor_ptr, *other_ptr));
   g_bytes_used += t->bytes();
   return t;
 }
 
-void *_lessThanEqual(void *tensor, void *other) {
-  auto *tensor_ptr = reinterpret_cast<fl::Tensor *>(tensor);
-  auto *other_ptr = reinterpret_cast<fl::Tensor *>(other);
-  auto *t = new fl::Tensor(fl::lessThanEqual(*tensor_ptr, *other_ptr));
+void* _lessThanEqual(void *tensor, void *other) {
+  auto *tensor_ptr = reinterpret_cast<fl::Tensor*>(tensor);
+  auto *other_ptr = reinterpret_cast<fl::Tensor*>(other);
+  auto* t = new fl::Tensor(fl::lessThanEqual(*tensor_ptr, *other_ptr));
   g_bytes_used += t->bytes();
   return t;
 }
 
-void *_greaterThan(void *tensor, void *other) {
-  auto *tensor_ptr = reinterpret_cast<fl::Tensor *>(tensor);
-  auto *other_ptr = reinterpret_cast<fl::Tensor *>(other);
-  auto *t = new fl::Tensor(fl::greaterThan(*tensor_ptr, *other_ptr));
+void* _greaterThan(void *tensor, void *other) {
+  auto *tensor_ptr = reinterpret_cast<fl::Tensor*>(tensor);
+  auto *other_ptr = reinterpret_cast<fl::Tensor*>(other);
+  auto* t = new fl::Tensor(fl::greaterThan(*tensor_ptr, *other_ptr));
   g_bytes_used += t->bytes();
   return t;
 }
 
-void *_greaterThanEqual(void *tensor, void *other) {
-  auto *tensor_ptr = reinterpret_cast<fl::Tensor *>(tensor);
-  auto *other_ptr = reinterpret_cast<fl::Tensor *>(other);
-  auto *t = new fl::Tensor(fl::greaterThanEqual(*tensor_ptr, *other_ptr));
+void* _greaterThanEqual(void *tensor, void *other) {
+  auto *tensor_ptr = reinterpret_cast<fl::Tensor*>(tensor);
+  auto *other_ptr = reinterpret_cast<fl::Tensor*>(other);
+  auto* t = new fl::Tensor(fl::greaterThanEqual(*tensor_ptr, *other_ptr));
   g_bytes_used += t->bytes();
   return t;
 }
 
-void *_logicalOr(void *tensor, void *other) {
-  auto *tensor_ptr = reinterpret_cast<fl::Tensor *>(tensor);
-  auto *other_ptr = reinterpret_cast<fl::Tensor *>(other);
-  auto *t = new fl::Tensor(fl::logicalOr(*tensor_ptr, *other_ptr));
+void* _logicalOr(void *tensor, void *other) {
+  auto *tensor_ptr = reinterpret_cast<fl::Tensor*>(tensor);
+  auto *other_ptr = reinterpret_cast<fl::Tensor*>(other);
+  auto* t = new fl::Tensor(fl::logicalOr(*tensor_ptr, *other_ptr));
   g_bytes_used += t->bytes();
   return t;
 }
 
-void *_logicalAnd(void *tensor, void *other) {
-  auto *tensor_ptr = reinterpret_cast<fl::Tensor *>(tensor);
-  auto *other_ptr = reinterpret_cast<fl::Tensor *>(other);
-  auto *t = new fl::Tensor(fl::logicalAnd(*tensor_ptr, *other_ptr));
+void* _logicalAnd(void *tensor, void *other) {
+  auto *tensor_ptr = reinterpret_cast<fl::Tensor*>(tensor);
+  auto *other_ptr = reinterpret_cast<fl::Tensor*>(other);
+  auto* t = new fl::Tensor(fl::logicalAnd(*tensor_ptr, *other_ptr));
   g_bytes_used += t->bytes();
   return t;
 }
 
-void *_mod(void *tensor, void *other) {
-  auto *tensor_ptr = reinterpret_cast<fl::Tensor *>(tensor);
-  auto *other_ptr = reinterpret_cast<fl::Tensor *>(other);
-  auto *t = new fl::Tensor(fl::mod(*tensor_ptr, *other_ptr));
+void* _mod(void *tensor, void *other) {
+  auto *tensor_ptr = reinterpret_cast<fl::Tensor*>(tensor);
+  auto *other_ptr = reinterpret_cast<fl::Tensor*>(other);
+  auto* t = new fl::Tensor(fl::mod(*tensor_ptr, *other_ptr));
   g_bytes_used += t->bytes();
   return t;
 }
 
-void *_bitwiseAnd(void *tensor, void *other) {
-  auto *tensor_ptr = reinterpret_cast<fl::Tensor *>(tensor);
-  auto *other_ptr = reinterpret_cast<fl::Tensor *>(other);
-  auto *t = new fl::Tensor(fl::bitwiseAnd(*tensor_ptr, *other_ptr));
+void* _bitwiseAnd(void *tensor, void *other) {
+  auto *tensor_ptr = reinterpret_cast<fl::Tensor*>(tensor);
+  auto *other_ptr = reinterpret_cast<fl::Tensor*>(other);
+  auto* t = new fl::Tensor(fl::bitwiseAnd(*tensor_ptr, *other_ptr));
   g_bytes_used += t->bytes();
   return t;
 }
 
-void *_bitwiseOr(void *tensor, void *other) {
-  auto *tensor_ptr = reinterpret_cast<fl::Tensor *>(tensor);
-  auto *other_ptr = reinterpret_cast<fl::Tensor *>(other);
-  auto *t = new fl::Tensor(fl::bitwiseOr(*tensor_ptr, *other_ptr));
+void* _bitwiseOr(void *tensor, void *other) {
+  auto *tensor_ptr = reinterpret_cast<fl::Tensor*>(tensor);
+  auto *other_ptr = reinterpret_cast<fl::Tensor*>(other);
+  auto* t = new fl::Tensor(fl::bitwiseOr(*tensor_ptr, *other_ptr));
   g_bytes_used += t->bytes();
   return t;
 }
 
-void *_bitwiseXor(void *tensor, void *other) {
-  auto *tensor_ptr = reinterpret_cast<fl::Tensor *>(tensor);
-  auto *other_ptr = reinterpret_cast<fl::Tensor *>(other);
-  auto *t = new fl::Tensor(fl::bitwiseXor(*tensor_ptr, *other_ptr));
+void* _bitwiseXor(void *tensor, void *other) {
+  auto *tensor_ptr = reinterpret_cast<fl::Tensor*>(tensor);
+  auto *other_ptr = reinterpret_cast<fl::Tensor*>(other);
+  auto* t = new fl::Tensor(fl::bitwiseXor(*tensor_ptr, *other_ptr));
   g_bytes_used += t->bytes();
   return t;
 }
 
-void *_lShift(void *tensor, void *other) {
-  auto *tensor_ptr = reinterpret_cast<fl::Tensor *>(tensor);
-  auto *other_ptr = reinterpret_cast<fl::Tensor *>(other);
-  auto *t = new fl::Tensor(fl::lShift(*tensor_ptr, *other_ptr));
+void* _lShift(void *tensor, void *other) {
+  auto *tensor_ptr = reinterpret_cast<fl::Tensor*>(tensor);
+  auto *other_ptr = reinterpret_cast<fl::Tensor*>(other);
+  auto* t = new fl::Tensor(fl::lShift(*tensor_ptr, *other_ptr));
   g_bytes_used += t->bytes();
   return t;
 }
 
-void *_rShift(void *tensor, void *other) {
-  auto *tensor_ptr = reinterpret_cast<fl::Tensor *>(tensor);
-  auto *other_ptr = reinterpret_cast<fl::Tensor *>(other);
-  auto *t = new fl::Tensor(fl::rShift(*tensor_ptr, *other_ptr));
+void* _rShift(void *tensor, void *other) {
+  auto *tensor_ptr = reinterpret_cast<fl::Tensor*>(tensor);
+  auto *other_ptr = reinterpret_cast<fl::Tensor*>(other);
+  auto* t = new fl::Tensor(fl::rShift(*tensor_ptr, *other_ptr));
   g_bytes_used += t->bytes();
   return t;
 }
 
-void *_minimum(void *tensor, void *other) {
-  auto *tensor_ptr = reinterpret_cast<fl::Tensor *>(tensor);
-  auto *other_ptr = reinterpret_cast<fl::Tensor *>(other);
-  auto *t = new fl::Tensor(fl::minimum(*tensor_ptr, *other_ptr));
+void* _minimum(void *tensor, void *other) {
+  auto *tensor_ptr = reinterpret_cast<fl::Tensor*>(tensor);
+  auto *other_ptr = reinterpret_cast<fl::Tensor*>(other);
+  auto* t = new fl::Tensor(fl::minimum(*tensor_ptr, *other_ptr));
   g_bytes_used += t->bytes();
   return t;
 }
 
-void *_maximum(void *tensor, void *other) {
-  auto *tensor_ptr = reinterpret_cast<fl::Tensor *>(tensor);
-  auto *other_ptr = reinterpret_cast<fl::Tensor *>(other);
-  auto *t = new fl::Tensor(fl::maximum(*tensor_ptr, *other_ptr));
+void* _maximum(void *tensor, void *other) {
+  auto *tensor_ptr = reinterpret_cast<fl::Tensor*>(tensor);
+  auto *other_ptr = reinterpret_cast<fl::Tensor*>(other);
+  auto* t = new fl::Tensor(fl::maximum(*tensor_ptr, *other_ptr));
   g_bytes_used += t->bytes();
   return t;
 }
 
-void *_power(void *tensor, void *other) {
-  auto *tensor_ptr = reinterpret_cast<fl::Tensor *>(tensor);
-  auto *other_ptr = reinterpret_cast<fl::Tensor *>(other);
-  auto *t = new fl::Tensor(fl::power(*tensor_ptr, *other_ptr));
+void* _power(void *tensor, void *other) {
+  auto *tensor_ptr = reinterpret_cast<fl::Tensor*>(tensor);
+  auto *other_ptr = reinterpret_cast<fl::Tensor*>(other);
+  auto* t = new fl::Tensor(fl::power(*tensor_ptr, *other_ptr));
   g_bytes_used += t->bytes();
   return t;
 }
 
-void *_matmul(void *tensor, void *other) {
-  auto *tensor_ptr = reinterpret_cast<fl::Tensor *>(tensor);
-  auto *other_ptr = reinterpret_cast<fl::Tensor *>(other);
+void* _matmul(void *tensor, void *other) {
+  auto *tensor_ptr = reinterpret_cast<fl::Tensor*>(tensor);
+  auto *other_ptr = reinterpret_cast<fl::Tensor*>(other);
   if (g_row_major) {
-    auto *t = new fl::Tensor(fl::matmul(*other_ptr, *tensor_ptr));
-    g_bytes_used += t->bytes();
-    return t;
+  auto* t = new fl::Tensor(fl::matmul(*other_ptr, *tensor_ptr));
+  g_bytes_used += t->bytes();
+  return t;
   } else {
-    auto *t = new fl::Tensor(fl::matmul(*tensor_ptr, *other_ptr));
-    g_bytes_used += t->bytes();
-    return t;
+  auto* t = new fl::Tensor(fl::matmul(*tensor_ptr, *other_ptr));
+  g_bytes_used += t->bytes();
+  return t;
   }
 }
 
-void *_amin(void *tensor, void *axes_ptr, int64_t axes_len, bool keep_dims) {
-  auto *tensor_ptr = reinterpret_cast<fl::Tensor *>(tensor);
-  auto axes =
-      arrayArg<int>(axes_ptr, axes_len, g_row_major, tensor_ptr->ndim());
-  auto *t = new fl::Tensor(fl::amin(*tensor_ptr, axes, keep_dims));
+void* _amin(void *tensor, void *axes_ptr, int64_t axes_len, bool keep_dims) {
+  auto *tensor_ptr = reinterpret_cast<fl::Tensor*>(tensor);
+  auto axes = arrayArg<int>(axes_ptr, axes_len, g_row_major, tensor_ptr->ndim());
+  auto* t = new fl::Tensor(fl::amin(*tensor_ptr, axes, keep_dims));
   g_bytes_used += t->bytes();
   return t;
 }
 
-void *_amax(void *tensor, void *axes_ptr, int64_t axes_len, bool keep_dims) {
-  auto *tensor_ptr = reinterpret_cast<fl::Tensor *>(tensor);
-  auto axes =
-      arrayArg<int>(axes_ptr, axes_len, g_row_major, tensor_ptr->ndim());
-  auto *t = new fl::Tensor(fl::amax(*tensor_ptr, axes, keep_dims));
+void* _amax(void *tensor, void *axes_ptr, int64_t axes_len, bool keep_dims) {
+  auto *tensor_ptr = reinterpret_cast<fl::Tensor*>(tensor);
+  auto axes = arrayArg<int>(axes_ptr, axes_len, g_row_major, tensor_ptr->ndim());
+  auto* t = new fl::Tensor(fl::amax(*tensor_ptr, axes, keep_dims));
   g_bytes_used += t->bytes();
   return t;
 }
 
-void *_argmin(void *tensor, uint32_t axis, bool keep_dims) {
-  auto *tensor_ptr = reinterpret_cast<fl::Tensor *>(tensor);
-  auto *t = new fl::Tensor(fl::argmin(*tensor_ptr, axis, keep_dims));
+void* _argmin(void *tensor, uint32_t axis, bool keep_dims) {
+  auto *tensor_ptr = reinterpret_cast<fl::Tensor*>(tensor);
+  auto* t = new fl::Tensor(fl::argmin(*tensor_ptr, axis, keep_dims));
   g_bytes_used += t->bytes();
   return t;
 }
 
-void *_argmax(void *tensor, uint32_t axis, bool keep_dims) {
-  auto *tensor_ptr = reinterpret_cast<fl::Tensor *>(tensor);
-  auto *t = new fl::Tensor(fl::argmax(*tensor_ptr, axis, keep_dims));
+void* _argmax(void *tensor, uint32_t axis, bool keep_dims) {
+  auto *tensor_ptr = reinterpret_cast<fl::Tensor*>(tensor);
+  auto* t = new fl::Tensor(fl::argmax(*tensor_ptr, axis, keep_dims));
   g_bytes_used += t->bytes();
   return t;
 }
 
-void *_sum(void *tensor, void *axes_ptr, int64_t axes_len, bool keep_dims) {
-  auto *tensor_ptr = reinterpret_cast<fl::Tensor *>(tensor);
-  auto axes =
-      arrayArg<int>(axes_ptr, axes_len, g_row_major, tensor_ptr->ndim());
-  auto *t = new fl::Tensor(fl::sum(*tensor_ptr, axes, keep_dims));
+void* _sum(void *tensor, void *axes_ptr, int64_t axes_len, bool keep_dims) {
+  auto *tensor_ptr = reinterpret_cast<fl::Tensor*>(tensor);
+  auto axes = arrayArg<int>(axes_ptr, axes_len, g_row_major, tensor_ptr->ndim());
+  auto* t = new fl::Tensor(fl::sum(*tensor_ptr, axes, keep_dims));
   g_bytes_used += t->bytes();
   return t;
 }
 
-void *_cumsum(void *tensor, uint32_t axis) {
-  auto *tensor_ptr = reinterpret_cast<fl::Tensor *>(tensor);
-  auto *t = new fl::Tensor(fl::cumsum(*tensor_ptr, axis));
+void* _cumsum(void *tensor, uint32_t axis) {
+  auto *tensor_ptr = reinterpret_cast<fl::Tensor*>(tensor);
+  auto* t = new fl::Tensor(fl::cumsum(*tensor_ptr, axis));
   g_bytes_used += t->bytes();
   return t;
 }
 
-void *_mean(void *tensor, void *axes_ptr, int64_t axes_len, bool keep_dims) {
-  auto *tensor_ptr = reinterpret_cast<fl::Tensor *>(tensor);
-  auto axes =
-      arrayArg<int>(axes_ptr, axes_len, g_row_major, tensor_ptr->ndim());
-  auto *t = new fl::Tensor(fl::mean(*tensor_ptr, axes, keep_dims));
+void* _mean(void *tensor, void *axes_ptr, int64_t axes_len, bool keep_dims) {
+  auto *tensor_ptr = reinterpret_cast<fl::Tensor*>(tensor);
+  auto axes = arrayArg<int>(axes_ptr, axes_len, g_row_major, tensor_ptr->ndim());
+  auto* t = new fl::Tensor(fl::mean(*tensor_ptr, axes, keep_dims));
   g_bytes_used += t->bytes();
   return t;
 }
 
-void *_median(void *tensor, void *axes_ptr, int64_t axes_len, bool keep_dims) {
-  auto *tensor_ptr = reinterpret_cast<fl::Tensor *>(tensor);
-  auto axes =
-      arrayArg<int>(axes_ptr, axes_len, g_row_major, tensor_ptr->ndim());
-  auto *t = new fl::Tensor(fl::median(*tensor_ptr, axes, keep_dims));
+void* _median(void *tensor, void *axes_ptr, int64_t axes_len, bool keep_dims) {
+  auto *tensor_ptr = reinterpret_cast<fl::Tensor*>(tensor);
+  auto axes = arrayArg<int>(axes_ptr, axes_len, g_row_major, tensor_ptr->ndim());
+  auto* t = new fl::Tensor(fl::median(*tensor_ptr, axes, keep_dims));
   g_bytes_used += t->bytes();
   return t;
 }
 
-void *_var(void *tensor, void *axes_ptr, int64_t axes_len, bool bias,
-           bool keep_dims) {
-  auto *tensor_ptr = reinterpret_cast<fl::Tensor *>(tensor);
-  auto axes =
-      arrayArg<int>(axes_ptr, axes_len, g_row_major, tensor_ptr->ndim());
-  auto *t = new fl::Tensor(fl::var(*tensor_ptr, axes, bias, keep_dims));
+void* _var(void *tensor, void *axes_ptr, int64_t axes_len, bool bias, bool keep_dims) {
+  auto *tensor_ptr = reinterpret_cast<fl::Tensor*>(tensor);
+  auto axes = arrayArg<int>(axes_ptr, axes_len, g_row_major, tensor_ptr->ndim());
+  auto* t = new fl::Tensor(fl::var(*tensor_ptr, axes, bias, keep_dims));
   g_bytes_used += t->bytes();
   return t;
 }
 
-void *_std(void *tensor, void *axes_ptr, int64_t axes_len, bool keep_dims) {
-  auto *tensor_ptr = reinterpret_cast<fl::Tensor *>(tensor);
-  auto axes =
-      arrayArg<int>(axes_ptr, axes_len, g_row_major, tensor_ptr->ndim());
-  auto *t = new fl::Tensor(fl::std(*tensor_ptr, axes, keep_dims));
+void* _std(void *tensor, void *axes_ptr, int64_t axes_len, bool keep_dims) {
+  auto *tensor_ptr = reinterpret_cast<fl::Tensor*>(tensor);
+  auto axes = arrayArg<int>(axes_ptr, axes_len, g_row_major, tensor_ptr->ndim());
+  auto* t = new fl::Tensor(fl::std(*tensor_ptr, axes, keep_dims));
   g_bytes_used += t->bytes();
   return t;
 }
 
-void *_norm(void *tensor, void *axes_ptr, int64_t axes_len, double p,
-            bool keep_dims) {
-  auto *tensor_ptr = reinterpret_cast<fl::Tensor *>(tensor);
-  auto axes =
-      arrayArg<int>(axes_ptr, axes_len, g_row_major, tensor_ptr->ndim());
-  auto *t = new fl::Tensor(fl::norm(*tensor_ptr, axes, p, keep_dims));
+void* _norm(void *tensor, void *axes_ptr, int64_t axes_len, double p, bool keep_dims) {
+  auto *tensor_ptr = reinterpret_cast<fl::Tensor*>(tensor);
+  auto axes = arrayArg<int>(axes_ptr, axes_len, g_row_major, tensor_ptr->ndim());
+  auto* t = new fl::Tensor(fl::norm(*tensor_ptr, axes, p, keep_dims));
   g_bytes_used += t->bytes();
   return t;
 }
 
-void *_countNonzero(void *tensor, void *axes_ptr, int64_t axes_len,
-                    bool keep_dims) {
-  auto *tensor_ptr = reinterpret_cast<fl::Tensor *>(tensor);
-  auto axes =
-      arrayArg<int>(axes_ptr, axes_len, g_row_major, tensor_ptr->ndim());
-  auto *t = new fl::Tensor(fl::countNonzero(*tensor_ptr, axes, keep_dims));
+void* _countNonzero(void *tensor, void *axes_ptr, int64_t axes_len, bool keep_dims) {
+  auto *tensor_ptr = reinterpret_cast<fl::Tensor*>(tensor);
+  auto axes = arrayArg<int>(axes_ptr, axes_len, g_row_major, tensor_ptr->ndim());
+  auto* t = new fl::Tensor(fl::countNonzero(*tensor_ptr, axes, keep_dims));
   g_bytes_used += t->bytes();
   return t;
 }
 
-void *_any(void *tensor, void *axes_ptr, int64_t axes_len, bool keep_dims) {
-  auto *tensor_ptr = reinterpret_cast<fl::Tensor *>(tensor);
-  auto axes =
-      arrayArg<int>(axes_ptr, axes_len, g_row_major, tensor_ptr->ndim());
-  auto *t = new fl::Tensor(fl::any(*tensor_ptr, axes, keep_dims));
+void* _any(void *tensor, void *axes_ptr, int64_t axes_len, bool keep_dims) {
+  auto *tensor_ptr = reinterpret_cast<fl::Tensor*>(tensor);
+  auto axes = arrayArg<int>(axes_ptr, axes_len, g_row_major, tensor_ptr->ndim());
+  auto* t = new fl::Tensor(fl::any(*tensor_ptr, axes, keep_dims));
   g_bytes_used += t->bytes();
   return t;
 }
 
-void *_all(void *tensor, void *axes_ptr, int64_t axes_len, bool keep_dims) {
-  auto *tensor_ptr = reinterpret_cast<fl::Tensor *>(tensor);
-  auto axes =
-      arrayArg<int>(axes_ptr, axes_len, g_row_major, tensor_ptr->ndim());
-  auto *t = new fl::Tensor(fl::all(*tensor_ptr, axes, keep_dims));
+void* _all(void *tensor, void *axes_ptr, int64_t axes_len, bool keep_dims) {
+  auto *tensor_ptr = reinterpret_cast<fl::Tensor*>(tensor);
+  auto axes = arrayArg<int>(axes_ptr, axes_len, g_row_major, tensor_ptr->ndim());
+  auto* t = new fl::Tensor(fl::all(*tensor_ptr, axes, keep_dims));
   g_bytes_used += t->bytes();
   return t;
 }

--- a/shumai/tensor/tensor_interface.ts
+++ b/shumai/tensor/tensor_interface.ts
@@ -1,5 +1,6 @@
 interface TensorInterface {
   ptr: number
+  requires_grad: boolean
   elements: number
 }
 

--- a/shumai/tensor/tensor_ops_gen.ts
+++ b/shumai/tensor/tensor_ops_gen.ts
@@ -2,7 +2,7 @@
 import { FFIType } from 'bun:ffi'
 import { arrayArg } from '../ffi/ffi_bind_utils'
 import { fl } from '../ffi/ffi_flashlight'
-import { Tensor, wrapFLTensor } from './tensor'
+import { Tensor } from './tensor'
 
 export function rand(shape: number[]) {
   const [shape_ptr, shape_len] = arrayArg(shape, FFIType.i64)

--- a/shumai/tensor/tensor_ops_shim_gen.ts
+++ b/shumai/tensor/tensor_ops_shim_gen.ts
@@ -4,7 +4,7 @@ import { arrayArg } from '../ffi/ffi_bind_utils'
 import { fl } from '../ffi/ffi_flashlight'
 import { TensorInterface } from './tensor_interface'
 import type { Tensor } from './tensor'
-export const gen_tensor_op_shim = (_Tensor: (...args: any[]) => Tensor) => {
+export const gen_tensor_op_shim = (_Tensor: new (...args: unknown[]) => Tensor) => {
   return {
     reshape(shape: number[]) {
       const [shape_ptr, shape_len] = arrayArg(shape, FFIType.i64)

--- a/shumai/util/iterators.ts
+++ b/shumai/util/iterators.ts
@@ -36,7 +36,7 @@ export function* viter(arraylike) {
   console.log(`\u001b[2K100% ${len}/${len}\u001b[A\n`)
 }
 
-export function shuffle(array: any[]) {
+export function shuffle<T>(array: T[]): T[] {
   let curr_idx: number = array.length
   let rand_idx: number
 

--- a/test/isinf.test.ts
+++ b/test/isinf.test.ts
@@ -1,6 +1,6 @@
-import { it, describe } from 'bun:test'
-import * as sm from '@shumai/shumai'
-import { expectArraysClose } from './utils'
+import { /*it,*/ describe } from 'bun:test'
+// import * as sm from '@shumai/shumai'
+// import { expectArraysClose } from './utils'
 
 describe('isinf', () => {
   /* TODO: FIX - CURRENTLY FAILS (Throws C++ Exception CUDA Backend Only)

--- a/test/lstm.test.ts
+++ b/test/lstm.test.ts
@@ -18,7 +18,7 @@ describe('lstm', () => {
     const h = sm.full([1, 128], 0)
     const c = sm.full([1, 128], 0)
     const l = sm.module.lstm(64, 128)
-    const [hn, cn] = l(x, h, c)
+    const [hn] = l(x, h, c)
     hn.sum().backward()
     expect(!!x.grad).toBe(true)
   })

--- a/test/util.test.ts
+++ b/test/util.test.ts
@@ -29,7 +29,7 @@ describe('range', () => {
 
 describe('shuffle', () => {
   it('basic', () => {
-    const a = []
+    const a: number[] = []
     for (const i of sm.util.range(100)) {
       a.push(i)
     }
@@ -38,7 +38,7 @@ describe('shuffle', () => {
   })
 
   it('same elemnts', () => {
-    const a = []
+    const a: number[] = []
     for (const i of sm.util.range(100)) {
       a.push(i)
     }

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -1,5 +1,5 @@
 import { expect } from 'bun:test'
-import type { Tensor } from '../src/tensor/tensor'
+import type { Tensor } from '@shumai/shumai'
 
 export const calcSizeFromShape = (arr: number[]) =>
   arr.reduce((acc, val, i) => (i === 0 ? val : acc * val), 0)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
     // "bun-types" is the important part
     "types": ["bun-types"],
     "paths": {
-      "@shumai/shumai": ["./shumai.ts"],
+      "@shumai/shumai": ["./shumai/index.ts"],
     }
   },
   "exclude": ["examples/*.js", "python_comparison/*.js"]


### PR DESCRIPTION
Changes to Resolve Tensor Type Errors:

- Update `scripts/gen_binding.py` to correctly gen types in `shumai/tensor/tensor_ops_shim_gen.ts` post-inlining wrapFlFunc
- Accordingly, I ran `sh scripts/gen_all_binding.sh` to update the generated types (this also updated `shumai/cpp/binding_gen.inl` as well, but I didn't alter the code that generates this, so it appears it needed to be run)
- Update `shumai/tensor/tensor_interface.ts` to include `requires_grad` property (resolves type error in `shumai/tensor/tensor_ops_shim_gen.ts` as it references the exported interface
- Export the Tensor interface (resolves TS type errors where generated ops weren't properly typed on `Tensor` when imported)

General cleanup:
- Update glob in `package.json` files property to include all `.ts` files in the `shumai` dir
- Update `package.json` to remove `--quiet` flag when running `bun format` (bun prints warnings, which can be ignored, but encourage better TS practices)
- fix ESLint warning where possible (add ESLint ignore comments where necessary, resolve otherwise)
- fix a few type issues in benchmarks (e.g. `Math.round(tensor)` -> `Math.round(tensor.toFloat32())`)