### PR TITLE
Update io types (clean up tests/examples); add lessThan tests

### DIFF
--- a/scripts/gen_binding.py
+++ b/scripts/gen_binding.py
@@ -200,7 +200,7 @@ to_ts = {
     "uint32_t": "number",
     "uint64_t": "number",
     "Tensor": "Tensor",
-    "Shape": "number[]",
+    "Shape": "BigInt64Array | number[]",
     "Axes": "number | number[]",
 }
 

--- a/shumai/io/network.ts
+++ b/shumai/io/network.ts
@@ -19,27 +19,33 @@ export function encode(tensor: sm.Tensor): ArrayBuffer {
   return buf.buffer
 }
 
-export function decode(obj: Response | ArrayBuffer): sm.Tensor {
-  function impl(buf) {
+export function decode(obj: Response | ArrayBuffer) {
+  function impl(buf: ArrayBuffer) {
     const shape_len = new Int32Array(buf, 0, 2)[0]
     const shape = new BigInt64Array(buf, 8 /* 8 byte offset mandated alignement */, shape_len)
     const t = sm.tensor(new Float32Array(buf, 8 + 8 * shape_len))
-    return t.reshape(shape)
+    return t.reshape(shape as unknown as number[])
   }
 
   if (obj.constructor === Response || obj.constructor === Request) {
-    return new Promise((resolve) => {
-      obj.arrayBuffer().then((buf) => {
-        resolve(impl(buf))
+    return obj
+      .arrayBuffer()
+      .then((buf) => impl(buf))
+      .catch((e) => {
+        throw new Error(e.message)
       })
-    })
   } else if (obj.constructor === ArrayBuffer) {
     return impl(obj)
   }
   throw `Could not decode object: ${obj}`
 }
 
-export async function tfetch(url, tensor, options) {
+export async function tfetch(
+  url: string,
+  tensor?: sm.Tensor,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  options?: { id?: string; grad_fn?: (grad: any) => Promise<void> }
+): Promise<sm.Tensor> {
   let id = _unique_id
   if (options && options.id) {
     id = options.id
@@ -59,7 +65,7 @@ export async function tfetch(url, tensor, options) {
   })()
   const buff = await response.arrayBuffer()
   if (buff.byteLength) {
-    const t = decode(buff)
+    const t = await decode(buff)
     if (options && options.grad_fn) {
       t.requires_grad = true
       t.grad_callback_async = async () => {

--- a/shumai/io/network.ts
+++ b/shumai/io/network.ts
@@ -23,10 +23,10 @@ export function decodeBuffer(buf: ArrayBuffer) {
   const shape_len = new Int32Array(buf, 0, 2)[0]
   const shape = new BigInt64Array(buf, 8 /* 8 byte offset mandated alignement */, shape_len)
   const t = sm.tensor(new Float32Array(buf, 8 + 8 * shape_len))
-  return t.reshape(shape as unknown as number[])
+  return t.reshape(shape)
 }
 
-export function decode(obj: Response | ArrayBuffer) {
+export async function decode(obj: Response | ArrayBuffer) {
   return new Promise<sm.Tensor>((resolve, reject) => {
     if (obj.constructor === Response || obj.constructor === Request) {
       return obj

--- a/shumai/io/network.ts
+++ b/shumai/io/network.ts
@@ -27,19 +27,14 @@ export function decodeBuffer(buf: ArrayBuffer) {
 }
 
 export async function decode(obj: Response | ArrayBuffer) {
-  return new Promise<sm.Tensor>((resolve, reject) => {
-    if (obj.constructor === Response || obj.constructor === Request) {
-      return obj
-        .arrayBuffer()
-        .then((buf) => resolve(decodeBuffer(buf)))
-        .catch((e) => {
-          throw new Error(e.message)
-        })
-    } else if (obj.constructor === ArrayBuffer) {
-      resolve(decodeBuffer(obj))
-    }
-    reject(new Error(`Could not decode object: ${obj}`))
-  })
+  if (obj.constructor === Response || obj.constructor === Request) {
+    const buf = await obj.arrayBuffer()
+    return decodeBuffer(buf)
+  } else if (obj.constructor === ArrayBuffer) {
+    return decodeBuffer(obj)
+  } else {
+    throw new Error(`Could not decode object: ${obj}`)
+  }
 }
 
 export async function tfetch(
@@ -114,5 +109,15 @@ export function serve(request_dict, options) {
   Bun.serve({
     ...fetch_handler,
     ...options
+  })
+}
+
+function foo() {
+  return 1
+}
+
+function bar(): Promise<number> {
+  return new Promise((r, _) => {
+    r(1)
   })
 }

--- a/shumai/io/network.ts
+++ b/shumai/io/network.ts
@@ -111,13 +111,3 @@ export function serve(request_dict, options) {
     ...options
   })
 }
-
-function foo() {
-  return 1
-}
-
-function bar(): Promise<number> {
-  return new Promise((r, _) => {
-    r(1)
-  })
-}

--- a/shumai/tensor/tensor.ts
+++ b/shumai/tensor/tensor.ts
@@ -146,7 +146,7 @@ export class Tensor {
     )
   }
 
-  backward(jacobian) {
+  backward(jacobian?: Tensor) {
     return backward(this, jacobian)
   }
 

--- a/shumai/tensor/tensor_interface.ts
+++ b/shumai/tensor/tensor_interface.ts
@@ -2,6 +2,8 @@ interface TensorInterface {
   ptr: number
   requires_grad: boolean
   elements: number
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  grad_callback_async?: (grad: any) => Promise<void>
 }
 
 export { TensorInterface }

--- a/shumai/tensor/tensor_ops_gen.ts
+++ b/shumai/tensor/tensor_ops_gen.ts
@@ -4,7 +4,7 @@ import { arrayArg } from '../ffi/ffi_bind_utils'
 import { fl } from '../ffi/ffi_flashlight'
 import { Tensor } from './tensor'
 
-export function rand(shape: number[]) {
+export function rand(shape: BigInt64Array | number[]) {
   const [shape_ptr, shape_len] = arrayArg(shape, FFIType.i64)
   const _ptr = fl._rand(shape_ptr, shape_len)
   const requires_grad = false
@@ -15,7 +15,7 @@ export function rand(shape: number[]) {
   return t
 }
 
-export function randn(shape: number[]) {
+export function randn(shape: BigInt64Array | number[]) {
   const [shape_ptr, shape_len] = arrayArg(shape, FFIType.i64)
   const _ptr = fl._randn(shape_ptr, shape_len)
   const requires_grad = false
@@ -26,7 +26,7 @@ export function randn(shape: number[]) {
   return t
 }
 
-export function full(shape: number[], val: number) {
+export function full(shape: BigInt64Array | number[], val: number) {
   const [shape_ptr, shape_len] = arrayArg(shape, FFIType.i64)
   const _ptr = fl._full(shape_ptr, shape_len, Math.fround(val))
   const requires_grad = false
@@ -57,7 +57,7 @@ export function arange(start: number, end: number, step = 1) {
   return t
 }
 
-export function iota(dims: number[], tileDims: number[] = [1]) {
+export function iota(dims: BigInt64Array | number[], tileDims: BigInt64Array | number[] = [1]) {
   const [dims_ptr, dims_len] = arrayArg(dims, FFIType.i64)
   const [tileDims_ptr, tileDims_len] = arrayArg(tileDims, FFIType.i64)
   const _ptr = fl._iota(dims_ptr, dims_len, tileDims_ptr, tileDims_len)
@@ -69,7 +69,7 @@ export function iota(dims: number[], tileDims: number[] = [1]) {
   return t
 }
 
-export function reshape(tensor: Tensor, shape: number[]) {
+export function reshape(tensor: Tensor, shape: BigInt64Array | number[]) {
   const [shape_ptr, shape_len] = arrayArg(shape, FFIType.i64)
   const _ptr = fl._reshape(tensor.ptr, shape_ptr, shape_len)
   const requires_grad = tensor.requires_grad
@@ -80,7 +80,7 @@ export function reshape(tensor: Tensor, shape: number[]) {
   return t
 }
 
-export function transpose(tensor: Tensor, axes: number[]) {
+export function transpose(tensor: Tensor, axes: BigInt64Array | number[]) {
   const [axes_ptr, axes_len] = arrayArg(axes, FFIType.i64)
   const _ptr = fl._transpose(tensor.ptr, axes_ptr, axes_len)
   const requires_grad = tensor.requires_grad
@@ -91,7 +91,7 @@ export function transpose(tensor: Tensor, axes: number[]) {
   return t
 }
 
-export function tile(tensor: Tensor, shape: number[]) {
+export function tile(tensor: Tensor, shape: BigInt64Array | number[]) {
   const [shape_ptr, shape_len] = arrayArg(shape, FFIType.i64)
   const _ptr = fl._tile(tensor.ptr, shape_ptr, shape_len)
   const requires_grad = tensor.requires_grad

--- a/shumai/tensor/tensor_ops_interface_gen.ts
+++ b/shumai/tensor/tensor_ops_interface_gen.ts
@@ -6,10 +6,10 @@ interface TensorOpsInterface {
   full: (val: number) => Tensor
   identity: () => Tensor
   arange: (end: number, step?: number) => Tensor
-  iota: (tileDims?: number[]) => Tensor
-  reshape: (shape: number[]) => Tensor
-  transpose: (axes: number[]) => Tensor
-  tile: (shape: number[]) => Tensor
+  iota: (tileDims?: BigInt64Array | number[]) => Tensor
+  reshape: (shape: BigInt64Array | number[]) => Tensor
+  transpose: (axes: BigInt64Array | number[]) => Tensor
+  tile: (shape: BigInt64Array | number[]) => Tensor
   nonzero: () => Tensor
   negative: () => Tensor
   logicalNot: () => Tensor

--- a/shumai/tensor/tensor_ops_shim_gen.ts
+++ b/shumai/tensor/tensor_ops_shim_gen.ts
@@ -6,7 +6,7 @@ import { TensorInterface } from './tensor_interface'
 import type { Tensor } from './tensor'
 export const gen_tensor_op_shim = (_Tensor: new (...args: unknown[]) => Tensor) => {
   return {
-    reshape(shape: number[]) {
+    reshape(shape: BigInt64Array | number[]) {
       const [shape_ptr, shape_len] = arrayArg(shape, FFIType.i64)
       const _ptr = fl._reshape(this.ptr, shape_ptr, shape_len)
       const requires_grad = this.requires_grad
@@ -17,7 +17,7 @@ export const gen_tensor_op_shim = (_Tensor: new (...args: unknown[]) => Tensor) 
       return t
     },
 
-    transpose(axes: number[]) {
+    transpose(axes: BigInt64Array | number[]) {
       const [axes_ptr, axes_len] = arrayArg(axes, FFIType.i64)
       const _ptr = fl._transpose(this.ptr, axes_ptr, axes_len)
       const requires_grad = this.requires_grad
@@ -28,7 +28,7 @@ export const gen_tensor_op_shim = (_Tensor: new (...args: unknown[]) => Tensor) 
       return t
     },
 
-    tile(shape: number[]) {
+    tile(shape: BigInt64Array | number[]) {
       const [shape_ptr, shape_len] = arrayArg(shape, FFIType.i64)
       const _ptr = fl._tile(this.ptr, shape_ptr, shape_len)
       const requires_grad = this.requires_grad

--- a/shumai/util/index.ts
+++ b/shumai/util/index.ts
@@ -1,1 +1,2 @@
 export * from './iterators'
+export * from './types'

--- a/shumai/util/iterators.ts
+++ b/shumai/util/iterators.ts
@@ -1,3 +1,4 @@
+import { util } from '@shumai/shumai'
 export function* range(
   length_or_start: number,
   end_: number | null = null,
@@ -19,7 +20,7 @@ export function* range(
 }
 
 const chars = ['⡆', '⠇', '⠋', '⠙', '⠸', '⢰', '⣠', '⣄']
-export function* viter(arraylike) {
+export function* viter(arraylike: util.ArrayLike) {
   const is_num = arraylike.constructor === Number
   const len = is_num ? arraylike : arraylike.length
   if (!len) {

--- a/shumai/util/types.ts
+++ b/shumai/util/types.ts
@@ -1,0 +1,7 @@
+export type ArrayLike =
+  | Float32Array
+  | Float64Array
+  | Uint8Array
+  | BigInt64Array
+  | Int32Array
+  | number[]

--- a/test/io.test.ts
+++ b/test/io.test.ts
@@ -10,11 +10,11 @@ describe('io', () => {
     const bbuf = sm.io.encode(b)
     expectArraysClose(new Uint8Array(abuf), new Uint8Array(bbuf))
   })
-  it('decode', async () => {
+  it('decodeBuffer', () => {
     const a = sm.tensor(new Float32Array([1, 2, 3, 4])).reshape([2, 2])
     const abuf = sm.io.encode(a)
-    const b = await sm.io.decode(abuf)
-    const c = await sm.io.decode(abuf)
+    const b = sm.io.decodeBuffer(abuf)
+    const c = sm.io.decodeBuffer(abuf)
     expectArraysClose(b.toFloat32Array(), c.toFloat32Array())
     expect(areSameShape(b, c)).toBe(true)
   })

--- a/test/io.test.ts
+++ b/test/io.test.ts
@@ -10,18 +10,18 @@ describe('io', () => {
     const bbuf = sm.io.encode(b)
     expectArraysClose(new Uint8Array(abuf), new Uint8Array(bbuf))
   })
-  it('decode', () => {
+  it('decode', async () => {
     const a = sm.tensor(new Float32Array([1, 2, 3, 4])).reshape([2, 2])
     const abuf = sm.io.encode(a)
-    const b = sm.io.decode(abuf)
-    const c = sm.io.decode(abuf)
+    const b = await sm.io.decode(abuf)
+    const c = await sm.io.decode(abuf)
     expectArraysClose(b.toFloat32Array(), c.toFloat32Array())
     expect(areSameShape(b, c)).toBe(true)
   })
-  it('encode then decode', () => {
-    const a = sm.randn(128, 128)
+  it('encode then decode', async () => {
+    const a = sm.randn([128, 128])
     const abuf = sm.io.encode(a)
-    const b = sm.io.decode(abuf)
+    const b = await sm.io.decode(abuf)
     expectArraysClose(a.toFloat32Array(), b.toFloat32Array())
     expect(areSameShape(a, b)).toBe(true)
   })

--- a/test/lessThan.test.ts
+++ b/test/lessThan.test.ts
@@ -1,0 +1,184 @@
+import { it, describe, expect } from 'bun:test'
+import * as sm from '@shumai/shumai'
+import { expectArraysClose, isShape } from './utils'
+
+describe('lessThan', () => {
+  /* TODO: FIX - CURRENTLY FAILS */
+  it('basic (1D Binary Tensor)', () => {
+    const a = sm.tensor(new Float32Array([0, 1, 0, 1]))
+    const b = sm.tensor(new Float32Array([1, 1, 1, 1]))
+    const r = a.lessThan(b)
+    expect(isShape(r, [4])).toBe(true)
+    expectArraysClose(<Float32Array>r.valueOf(), [1, 0, 1, 0])
+  })
+
+  /* TODO: FIX - CURRENTLY FAILS */
+  it('basic (1D Tensor)', () => {
+    let a = sm.tensor(new Float32Array([1, 4, 5])),
+      b = sm.tensor(new Float32Array([2, 3, 5])),
+      r = sm.lessThan(a, b)
+    expect(isShape(r, [3])).toBe(true)
+    expectArraysClose(<Float32Array>r.valueOf(), [1, 0, 0])
+
+    a = sm.tensor(new Float32Array([2, 3, 4]))
+    b = sm.tensor(new Float32Array([2, 3, 4]))
+    r = a.lessThan(b)
+    expect(isShape(r, [3])).toBe(true)
+    expectArraysClose(<Float32Array>r.valueOf(), [0, 0, 0])
+
+    a = sm.tensor(new Float32Array([0, 0]))
+    b = sm.tensor(new Float32Array([3, 3]))
+    r = a.lessThan(b)
+    expect(isShape(r, [2])).toBe(true)
+    expectArraysClose(<Float32Array>r.valueOf(), [1, 1])
+
+    a = sm.tensor(new Float32Array([1.1, 4.1, 5.1]))
+    b = sm.tensor(new Float32Array([2.2, 3.2, 5.1]))
+    r = a.lessThan(b)
+    expect(isShape(r, [3])).toBe(true)
+    expectArraysClose(<Float32Array>r.valueOf(), [1, 0, 0])
+
+    a = sm.tensor(new Float32Array([2.31, 2.31, 2.31]))
+    b = sm.tensor(new Float32Array([2.31, 2.31, 2.31]))
+    r = a.lessThan(b)
+    expect(isShape(r, [3])).toBe(true)
+    expectArraysClose(<Float32Array>r.valueOf(), [0, 0, 0])
+
+    a = sm.tensor(new Float32Array([0.45, 0.123]))
+    b = sm.tensor(new Float32Array([3.123, 3.321]))
+    r = a.lessThan(b)
+    expect(isShape(r, [2])).toBe(true)
+    expectArraysClose(<Float32Array>r.valueOf(), [1, 1])
+  })
+
+  /* TODO: FIX - CURRENTLY FAILS */
+  it('1D Tensor with NaNs', () => {
+    const a = sm.tensor(new Float32Array([1.1, NaN, 2.1]))
+    const b = sm.tensor(new Float32Array([2.1, 3.1, NaN]))
+    const r = sm.lessThan(a, b)
+    expect(isShape(r, [3])).toBe(true)
+    expectArraysClose(<Float32Array>r.valueOf(), [1, 0, 0])
+  })
+
+  /* TODO: FIX - CURRENTLY FAILS */
+  it('2D Tensor', () => {
+    let a = sm.tensor(new Float32Array([1, 4, 5, 8, 9, 12])).reshape([2, 3]),
+      b = sm.tensor(new Float32Array([2, 3, 6, 7, 10, 11])).reshape([2, 3]),
+      r = sm.lessThan(a, b)
+    expect(isShape(r, [2, 3])).toBe(true)
+    expectArraysClose(<Float32Array>r.valueOf(), [1, 0, 1, 0, 1, 0])
+
+    a = sm.tensor(new Float32Array([0, 0, 1, 1])).reshape([2, 2])
+    b = sm.tensor(new Float32Array([0, 0, 1, 1])).reshape([2, 2])
+    r = a.lessThan(b)
+    expect(isShape(r, [2, 2])).toBe(true)
+    expectArraysClose(<Float32Array>r.valueOf(), [0, 0, 0, 0])
+
+    a = sm.tensor(new Float32Array([1.1, 4.1, 5.1, 8.1, 9.1, 12.1])).reshape([2, 3])
+    b = sm.tensor(new Float32Array([2.1, 3.1, 6.1, 7.1, 10.1, 11.1])).reshape([2, 3])
+    r = sm.lessThan(a, b)
+    expect(isShape(r, [2, 3])).toBe(true)
+    expectArraysClose(<Float32Array>r.valueOf(), [1, 0, 1, 0, 1, 0])
+
+    a = sm.tensor(new Float32Array([0.2, 0.2, 1.2, 1.2])).reshape([2, 2])
+    b = sm.tensor(new Float32Array([0.2, 0.2, 1.2, 1.2])).reshape([2, 2])
+    r = sm.lessThan(a, b)
+    expect(isShape(r, [2, 2])).toBe(true)
+    expectArraysClose(<Float32Array>r.valueOf(), [0, 0, 0, 0])
+  })
+
+  /* TODO: FIX - CURRENTLY FAILS */
+  it('2D Tensor with NaNs', () => {
+    const a = sm.tensor(new Float32Array([1.1, NaN, 0.1, NaN])).reshape([2, 2])
+    const b = sm.tensor(new Float32Array([0.1, NaN, 1.1, NaN])).reshape([2, 2])
+    const r = sm.lessThan(a, b)
+    expect(isShape(r, [2, 2])).toBe(true)
+    expectArraysClose(<Float32Array>r.valueOf(), [0, 0, 1, 0])
+  })
+
+  /* TODO: FIX - CURRENTLY FAILS */
+  it('3D Tensor', () => {
+    let a = sm.tensor(new Float32Array([1, 4, 5, 8, 9, 12])).reshape([2, 3, 1]),
+      b = sm.tensor(new Float32Array([2, 3, 6, 7, 10, 11])).reshape([2, 3, 1]),
+      r = sm.lessThan(a, b)
+    expect(isShape(r, [2, 3, 1])).toBe(true)
+    expectArraysClose(<Float32Array>r.valueOf(), [1, 0, 1, 0, 1, 0])
+
+    a = sm.tensor(new Float32Array([0, 0, 0, 1, 1, 1])).reshape([2, 3, 1])
+    b = sm.tensor(new Float32Array([0, 0, 0, 1, 1, 1])).reshape([2, 3, 1])
+    r = sm.lessThan(a, b)
+    expect(isShape(r, [2, 3, 1])).toBe(true)
+    expectArraysClose(<Float32Array>r.valueOf(), [0, 0, 0, 0, 0, 0])
+
+    a = sm.tensor(new Float32Array([1.1, 4.1, 5.1, 8.1, 9.1, 12.1])).reshape([2, 3, 1])
+    b = sm.tensor(new Float32Array([2.1, 3.1, 6.1, 7.1, 10.1, 11.1])).reshape([2, 3, 1])
+    r = sm.lessThan(a, b)
+    expect(isShape(r, [2, 3, 1])).toBe(true)
+    expectArraysClose(<Float32Array>r.valueOf(), [1, 0, 1, 0, 1, 0])
+
+    a = sm.tensor(new Float32Array([0.1, 0.1, 0.1, 1.1, 1.1, 1.0])).reshape([2, 3, 1])
+    b = sm.tensor(new Float32Array([0.1, 0.1, 0.1, 1.1, 1.1, 1.1])).reshape([2, 3, 1])
+    r = sm.lessThan(a, b)
+    expect(isShape(r, [2, 3, 1])).toBe(true)
+    expectArraysClose(<Float32Array>r.valueOf(), [0, 0, 0, 0, 0, 1])
+  })
+
+  /* TODO: FIX - CURRENTLY FAILS */
+  it('3D Tensor with NaNs', () => {
+    const a = sm.tensor(new Float32Array([1.1, NaN, 1.1, 0.1, 0.1, 0.1])).reshape([2, 3, 1])
+    const b = sm.tensor(new Float32Array([0.1, 0.1, 1.1, 1.1, 0.1, NaN])).reshape([2, 3, 1])
+    const r = a.lessThan(b)
+    expect(isShape(r, [2, 3, 1])).toBe(true)
+    expectArraysClose(<Float32Array>r.valueOf(), [0, 0, 0, 1, 0, 0])
+  })
+
+  /* TODO: FIX - CURRENTLY FAILS */
+  it('4D Tensor', () => {
+    let a = sm.tensor(new Float32Array([1, 4, 5, 8])).reshape([2, 2, 1, 1]),
+      b = sm.tensor(new Float32Array([2, 3, 6, 7])).reshape([2, 2, 1, 1]),
+      r = sm.lessThan(a, b)
+    expect(isShape(r, [2, 2, 1, 1])).toBe(true)
+    expectArraysClose(<Float32Array>r.valueOf(), [1, 0, 1, 0])
+
+    a = sm.tensor(new Float32Array([0, 1, 2, 3])).reshape([2, 2, 1, 1])
+    b = sm.tensor(new Float32Array([0, 1, 2, 3])).reshape([2, 2, 1, 1])
+    r = sm.lessThan(a, b)
+    expect(isShape(r, [2, 2, 1, 1])).toBe(true)
+    expectArraysClose(<Float32Array>r.valueOf(), [0, 0, 0, 0])
+
+    a = sm.tensor(new Float32Array([1, 1, 1, 1])).reshape([2, 2, 1, 1])
+    b = sm.tensor(new Float32Array([2, 2, 2, 2])).reshape([2, 2, 1, 1])
+    r = sm.lessThan(a, b)
+    expect(isShape(r, [2, 2, 1, 1])).toBe(true)
+    expectArraysClose(<Float32Array>r.valueOf(), [1, 1, 1, 1])
+
+    a = sm.tensor(new Float32Array([1.1, 4.1, 5.1, 8.1])).reshape([2, 2, 1, 1])
+    b = sm.tensor(new Float32Array([2.1, 3.1, 6.1, 7.1])).reshape([2, 2, 1, 1])
+    r = sm.lessThan(a, b)
+    expect(isShape(r, [2, 2, 1, 1])).toBe(true)
+    expectArraysClose(<Float32Array>r.valueOf(), [1, 0, 1, 0])
+
+    a = sm.tensor(new Float32Array([0.1, 1.1, 2.2, 3.3])).reshape([2, 2, 1, 1])
+    b = sm.tensor(new Float32Array([0.1, 1.1, 2.2, 3.3])).reshape([2, 2, 1, 1])
+    r = sm.lessThan(a, b)
+    expect(isShape(r, [2, 2, 1, 1])).toBe(true)
+    expectArraysClose(<Float32Array>r.valueOf(), [0, 0, 0, 0])
+
+    a = sm.tensor(new Float32Array([0.1, 0.1, 0.1, 0.1])).reshape([2, 2, 1, 1])
+    b = sm.tensor(new Float32Array([1.1, 1.1, 1.1, 1.1])).reshape([2, 2, 1, 1])
+    r = sm.lessThan(a, b)
+    expect(isShape(r, [2, 2, 1, 1])).toBe(true)
+    expectArraysClose(<Float32Array>r.valueOf(), [1, 1, 1, 1])
+  })
+
+  /* TODO: FIX - CURRENTLY FAILS */
+  it('4D Tensor with NaNs', () => {
+    const a = sm.tensor(new Float32Array([1.1, NaN, 0.1, 0.1])).reshape([2, 2, 1, 1])
+    const b = sm.tensor(new Float32Array([0.1, 1.1, 1.1, NaN])).reshape([2, 2, 1, 1])
+    const r = a.lessThan(b)
+    expect(isShape(r, [2, 2, 1, 1])).toBe(true)
+    expectArraysClose(<Float32Array>r.valueOf(), [0, 0, 1, 0])
+  })
+
+  /* TODO: unit tests for gradients once supported */
+})

--- a/test/lessThan.test.ts
+++ b/test/lessThan.test.ts
@@ -9,7 +9,7 @@ describe('lessThan', () => {
     const b = sm.tensor(new Float32Array([1, 1, 1, 1]))
     const r = a.lessThan(b)
     expect(isShape(r, [4])).toBe(true)
-    expectArraysClose(<Float32Array>r.valueOf(), [1, 0, 1, 0])
+    expectArraysClose(r.toFloat32Array(), [1, 0, 1, 0])
   })
 
   /* TODO: FIX - CURRENTLY FAILS */
@@ -18,37 +18,37 @@ describe('lessThan', () => {
       b = sm.tensor(new Float32Array([2, 3, 5])),
       r = sm.lessThan(a, b)
     expect(isShape(r, [3])).toBe(true)
-    expectArraysClose(<Float32Array>r.valueOf(), [1, 0, 0])
+    expectArraysClose(r.toFloat32Array(), [1, 0, 0])
 
     a = sm.tensor(new Float32Array([2, 3, 4]))
     b = sm.tensor(new Float32Array([2, 3, 4]))
     r = a.lessThan(b)
     expect(isShape(r, [3])).toBe(true)
-    expectArraysClose(<Float32Array>r.valueOf(), [0, 0, 0])
+    expectArraysClose(r.toFloat32Array(), [0, 0, 0])
 
     a = sm.tensor(new Float32Array([0, 0]))
     b = sm.tensor(new Float32Array([3, 3]))
     r = a.lessThan(b)
     expect(isShape(r, [2])).toBe(true)
-    expectArraysClose(<Float32Array>r.valueOf(), [1, 1])
+    expectArraysClose(r.toFloat32Array(), [1, 1])
 
     a = sm.tensor(new Float32Array([1.1, 4.1, 5.1]))
     b = sm.tensor(new Float32Array([2.2, 3.2, 5.1]))
     r = a.lessThan(b)
     expect(isShape(r, [3])).toBe(true)
-    expectArraysClose(<Float32Array>r.valueOf(), [1, 0, 0])
+    expectArraysClose(r.toFloat32Array(), [1, 0, 0])
 
     a = sm.tensor(new Float32Array([2.31, 2.31, 2.31]))
     b = sm.tensor(new Float32Array([2.31, 2.31, 2.31]))
     r = a.lessThan(b)
     expect(isShape(r, [3])).toBe(true)
-    expectArraysClose(<Float32Array>r.valueOf(), [0, 0, 0])
+    expectArraysClose(r.toFloat32Array(), [0, 0, 0])
 
     a = sm.tensor(new Float32Array([0.45, 0.123]))
     b = sm.tensor(new Float32Array([3.123, 3.321]))
     r = a.lessThan(b)
     expect(isShape(r, [2])).toBe(true)
-    expectArraysClose(<Float32Array>r.valueOf(), [1, 1])
+    expectArraysClose(r.toFloat32Array(), [1, 1])
   })
 
   /* TODO: FIX - CURRENTLY FAILS */
@@ -57,7 +57,7 @@ describe('lessThan', () => {
     const b = sm.tensor(new Float32Array([2.1, 3.1, NaN]))
     const r = sm.lessThan(a, b)
     expect(isShape(r, [3])).toBe(true)
-    expectArraysClose(<Float32Array>r.valueOf(), [1, 0, 0])
+    expectArraysClose(r.toFloat32Array(), [1, 0, 0])
   })
 
   /* TODO: FIX - CURRENTLY FAILS */
@@ -66,25 +66,25 @@ describe('lessThan', () => {
       b = sm.tensor(new Float32Array([2, 3, 6, 7, 10, 11])).reshape([2, 3]),
       r = sm.lessThan(a, b)
     expect(isShape(r, [2, 3])).toBe(true)
-    expectArraysClose(<Float32Array>r.valueOf(), [1, 0, 1, 0, 1, 0])
+    expectArraysClose(r.toFloat32Array(), [1, 0, 1, 0, 1, 0])
 
     a = sm.tensor(new Float32Array([0, 0, 1, 1])).reshape([2, 2])
     b = sm.tensor(new Float32Array([0, 0, 1, 1])).reshape([2, 2])
     r = a.lessThan(b)
     expect(isShape(r, [2, 2])).toBe(true)
-    expectArraysClose(<Float32Array>r.valueOf(), [0, 0, 0, 0])
+    expectArraysClose(r.toFloat32Array(), [0, 0, 0, 0])
 
     a = sm.tensor(new Float32Array([1.1, 4.1, 5.1, 8.1, 9.1, 12.1])).reshape([2, 3])
     b = sm.tensor(new Float32Array([2.1, 3.1, 6.1, 7.1, 10.1, 11.1])).reshape([2, 3])
     r = sm.lessThan(a, b)
     expect(isShape(r, [2, 3])).toBe(true)
-    expectArraysClose(<Float32Array>r.valueOf(), [1, 0, 1, 0, 1, 0])
+    expectArraysClose(r.toFloat32Array(), [1, 0, 1, 0, 1, 0])
 
     a = sm.tensor(new Float32Array([0.2, 0.2, 1.2, 1.2])).reshape([2, 2])
     b = sm.tensor(new Float32Array([0.2, 0.2, 1.2, 1.2])).reshape([2, 2])
     r = sm.lessThan(a, b)
     expect(isShape(r, [2, 2])).toBe(true)
-    expectArraysClose(<Float32Array>r.valueOf(), [0, 0, 0, 0])
+    expectArraysClose(r.toFloat32Array(), [0, 0, 0, 0])
   })
 
   /* TODO: FIX - CURRENTLY FAILS */
@@ -93,7 +93,7 @@ describe('lessThan', () => {
     const b = sm.tensor(new Float32Array([0.1, NaN, 1.1, NaN])).reshape([2, 2])
     const r = sm.lessThan(a, b)
     expect(isShape(r, [2, 2])).toBe(true)
-    expectArraysClose(<Float32Array>r.valueOf(), [0, 0, 1, 0])
+    expectArraysClose(r.toFloat32Array(), [0, 0, 1, 0])
   })
 
   /* TODO: FIX - CURRENTLY FAILS */
@@ -102,25 +102,25 @@ describe('lessThan', () => {
       b = sm.tensor(new Float32Array([2, 3, 6, 7, 10, 11])).reshape([2, 3, 1]),
       r = sm.lessThan(a, b)
     expect(isShape(r, [2, 3, 1])).toBe(true)
-    expectArraysClose(<Float32Array>r.valueOf(), [1, 0, 1, 0, 1, 0])
+    expectArraysClose(r.toFloat32Array(), [1, 0, 1, 0, 1, 0])
 
     a = sm.tensor(new Float32Array([0, 0, 0, 1, 1, 1])).reshape([2, 3, 1])
     b = sm.tensor(new Float32Array([0, 0, 0, 1, 1, 1])).reshape([2, 3, 1])
     r = sm.lessThan(a, b)
     expect(isShape(r, [2, 3, 1])).toBe(true)
-    expectArraysClose(<Float32Array>r.valueOf(), [0, 0, 0, 0, 0, 0])
+    expectArraysClose(r.toFloat32Array(), [0, 0, 0, 0, 0, 0])
 
     a = sm.tensor(new Float32Array([1.1, 4.1, 5.1, 8.1, 9.1, 12.1])).reshape([2, 3, 1])
     b = sm.tensor(new Float32Array([2.1, 3.1, 6.1, 7.1, 10.1, 11.1])).reshape([2, 3, 1])
     r = sm.lessThan(a, b)
     expect(isShape(r, [2, 3, 1])).toBe(true)
-    expectArraysClose(<Float32Array>r.valueOf(), [1, 0, 1, 0, 1, 0])
+    expectArraysClose(r.toFloat32Array(), [1, 0, 1, 0, 1, 0])
 
     a = sm.tensor(new Float32Array([0.1, 0.1, 0.1, 1.1, 1.1, 1.0])).reshape([2, 3, 1])
     b = sm.tensor(new Float32Array([0.1, 0.1, 0.1, 1.1, 1.1, 1.1])).reshape([2, 3, 1])
     r = sm.lessThan(a, b)
     expect(isShape(r, [2, 3, 1])).toBe(true)
-    expectArraysClose(<Float32Array>r.valueOf(), [0, 0, 0, 0, 0, 1])
+    expectArraysClose(r.toFloat32Array(), [0, 0, 0, 0, 0, 1])
   })
 
   /* TODO: FIX - CURRENTLY FAILS */
@@ -129,7 +129,7 @@ describe('lessThan', () => {
     const b = sm.tensor(new Float32Array([0.1, 0.1, 1.1, 1.1, 0.1, NaN])).reshape([2, 3, 1])
     const r = a.lessThan(b)
     expect(isShape(r, [2, 3, 1])).toBe(true)
-    expectArraysClose(<Float32Array>r.valueOf(), [0, 0, 0, 1, 0, 0])
+    expectArraysClose(r.toFloat32Array(), [0, 0, 0, 1, 0, 0])
   })
 
   /* TODO: FIX - CURRENTLY FAILS */
@@ -138,37 +138,37 @@ describe('lessThan', () => {
       b = sm.tensor(new Float32Array([2, 3, 6, 7])).reshape([2, 2, 1, 1]),
       r = sm.lessThan(a, b)
     expect(isShape(r, [2, 2, 1, 1])).toBe(true)
-    expectArraysClose(<Float32Array>r.valueOf(), [1, 0, 1, 0])
+    expectArraysClose(r.toFloat32Array(), [1, 0, 1, 0])
 
     a = sm.tensor(new Float32Array([0, 1, 2, 3])).reshape([2, 2, 1, 1])
     b = sm.tensor(new Float32Array([0, 1, 2, 3])).reshape([2, 2, 1, 1])
     r = sm.lessThan(a, b)
     expect(isShape(r, [2, 2, 1, 1])).toBe(true)
-    expectArraysClose(<Float32Array>r.valueOf(), [0, 0, 0, 0])
+    expectArraysClose(r.toFloat32Array(), [0, 0, 0, 0])
 
     a = sm.tensor(new Float32Array([1, 1, 1, 1])).reshape([2, 2, 1, 1])
     b = sm.tensor(new Float32Array([2, 2, 2, 2])).reshape([2, 2, 1, 1])
     r = sm.lessThan(a, b)
     expect(isShape(r, [2, 2, 1, 1])).toBe(true)
-    expectArraysClose(<Float32Array>r.valueOf(), [1, 1, 1, 1])
+    expectArraysClose(r.toFloat32Array(), [1, 1, 1, 1])
 
     a = sm.tensor(new Float32Array([1.1, 4.1, 5.1, 8.1])).reshape([2, 2, 1, 1])
     b = sm.tensor(new Float32Array([2.1, 3.1, 6.1, 7.1])).reshape([2, 2, 1, 1])
     r = sm.lessThan(a, b)
     expect(isShape(r, [2, 2, 1, 1])).toBe(true)
-    expectArraysClose(<Float32Array>r.valueOf(), [1, 0, 1, 0])
+    expectArraysClose(r.toFloat32Array(), [1, 0, 1, 0])
 
     a = sm.tensor(new Float32Array([0.1, 1.1, 2.2, 3.3])).reshape([2, 2, 1, 1])
     b = sm.tensor(new Float32Array([0.1, 1.1, 2.2, 3.3])).reshape([2, 2, 1, 1])
     r = sm.lessThan(a, b)
     expect(isShape(r, [2, 2, 1, 1])).toBe(true)
-    expectArraysClose(<Float32Array>r.valueOf(), [0, 0, 0, 0])
+    expectArraysClose(r.toFloat32Array(), [0, 0, 0, 0])
 
     a = sm.tensor(new Float32Array([0.1, 0.1, 0.1, 0.1])).reshape([2, 2, 1, 1])
     b = sm.tensor(new Float32Array([1.1, 1.1, 1.1, 1.1])).reshape([2, 2, 1, 1])
     r = sm.lessThan(a, b)
     expect(isShape(r, [2, 2, 1, 1])).toBe(true)
-    expectArraysClose(<Float32Array>r.valueOf(), [1, 1, 1, 1])
+    expectArraysClose(r.toFloat32Array(), [1, 1, 1, 1])
   })
 
   /* TODO: FIX - CURRENTLY FAILS */
@@ -177,7 +177,7 @@ describe('lessThan', () => {
     const b = sm.tensor(new Float32Array([0.1, 1.1, 1.1, NaN])).reshape([2, 2, 1, 1])
     const r = a.lessThan(b)
     expect(isShape(r, [2, 2, 1, 1])).toBe(true)
-    expectArraysClose(<Float32Array>r.valueOf(), [0, 0, 1, 0])
+    expectArraysClose(r.toFloat32Array(), [0, 0, 1, 0])
   })
 
   /* TODO: unit tests for gradients once supported */

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -1,6 +1,8 @@
 import { expect } from 'bun:test'
 import type { Tensor } from '@shumai/shumai'
 
+export type ArrayLike = Float32Array | Float64Array | Uint8Array | number[]
+
 export const calcSizeFromShape = (arr: number[]) =>
   arr.reduce((acc, val, i) => (i === 0 ? val : acc * val), 0)
 
@@ -34,11 +36,7 @@ export const isClose = (actual: number, expected: number, error = 0.001) => {
 }
 
 /* validates that actual && expected array are close (all values w/i given tolerance) */
-const isCloseArr = (
-  actual: Float32Array | number[],
-  expected: Float32Array | number[],
-  error: number
-) => {
+const isCloseArr = (actual: ArrayLike, expected: ArrayLike, error: number) => {
   const expLength = expected.length
   if (actual.length !== expLength) return false
 
@@ -49,8 +47,5 @@ const isCloseArr = (
   return true
 }
 
-export const expectArraysClose = (
-  actual: Float32Array | number[],
-  expected: Float32Array | number[],
-  error = 0.001
-) => expect(isCloseArr(actual, expected, error)).toBe(true)
+export const expectArraysClose = (actual: ArrayLike, expected: ArrayLike, error = 0.001) =>
+  expect(isCloseArr(actual, expected, error)).toBe(true)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,5 +14,5 @@
       "@shumai/shumai": ["./shumai/index.ts"],
     }
   },
-  "exclude": ["examples/*.js", "python_comparison/*.js"]
+  "exclude": ["examples/**/*.js"]
 }


### PR DESCRIPTION
Should provide more accurate runtime typings for newly added `io` functionality; fixed some ESLint Errors in the new code, added `lessThan` tests while cleaning up `io` tests  as we need to track down that float underflow issue. 