### PR TITLE
Unit tests for greaterThan, greaterThanEqual, lessThanEqual, & matmul

### DIFF
--- a/test/all.test.ts
+++ b/test/all.test.ts
@@ -1,0 +1,58 @@
+import { it, describe, expect } from 'bun:test'
+import * as sm from '@shumai/shumai'
+import { expectArraysClose, isShape } from './utils'
+
+describe('all', () => {
+  it('1D Tensor', () => {
+    let a = sm.tensor(new Float32Array([0, 0, 0]))
+    expectArraysClose(sm.all(a).toFloat32Array(), [0])
+
+    a = sm.tensor(new Float32Array([1, 0, 1]))
+    expectArraysClose(sm.all(a).toFloat32Array(), [0])
+
+    a = sm.tensor(new Float32Array([1, 1, 1]))
+    expectArraysClose(sm.all(a).toFloat32Array(), [1])
+  })
+  it('ignores NaNs', () => {
+    const a = sm.tensor(new Float32Array([1, NaN, 1]))
+    expectArraysClose(sm.all(a).toFloat32Array(), [1])
+  })
+  it('ignores NaNs', () => {
+    const a = sm.tensor(new Float32Array([1, NaN, 1]))
+    expectArraysClose(sm.all(a).toFloat32Array(), [1])
+  })
+  it('2D Tensor', () => {
+    const a = sm.tensor(new Float32Array([1, 1, 0, 0])).reshape([2, 2])
+    expectArraysClose(sm.all(a).toFloat32Array(), [0])
+  })
+  it('2D Tensor, axis=[0,1]', () => {
+    const a = sm.tensor(new Float32Array([1, 1, 0, 0, 1, 0])).reshape([2, 3])
+    expectArraysClose(sm.all(a, [0, 1]).toFloat32Array(), [0])
+  })
+  it('2D Tensor, axis=[0]/axis=[1]', () => {
+    const a = sm.tensor(new Float32Array([1, 1, 0, 0])).reshape([2, 2])
+    let r = sm.all(a, [0])
+    expect(isShape(r, [2])).toBe(true)
+    expectArraysClose(r.toFloat32Array(), [0, 0])
+
+    r = sm.all(a, [1])
+    expect(isShape(r, [2])).toBe(true)
+    expectArraysClose(r.toFloat32Array(), [1, 0])
+  })
+  it('2D Tensor, axis=[0] & keep_dims=true', () => {
+    const a = sm.tensor(new Float32Array([1, 1, 0, 0, 1, 0])).reshape([2, 3])
+    const r = a.all([0], true)
+    expect(isShape(r, [1, 3])).toBe(true)
+    expectArraysClose(r.toFloat32Array(), [0, 1, 0])
+  })
+  it('2D Tensor, axis=[-1]', () => {
+    const a = sm.tensor(new Float32Array([1, 1, 0, 0, 1, 0])).reshape([2, 3])
+    const r = sm.all(a, [-1])
+    expectArraysClose(r.toFloat32Array(), [0, 0])
+  })
+  it('2D Tensor, axis=[1]', () => {
+    const a = sm.tensor(new Float32Array([1, 1, 0, 0, 1, 0])).reshape([2, 3])
+    const r = sm.all(a, [1])
+    expectArraysClose(r.toFloat32Array(), [0, 0])
+  })
+})

--- a/test/argmax.test.ts
+++ b/test/argmax.test.ts
@@ -1,0 +1,68 @@
+import { it, describe, expect } from 'bun:test'
+import * as sm from '@shumai/shumai'
+import { expectArraysClose, isShape } from './utils'
+
+const THRESHOLD = 30
+
+describe('argmax', () => {
+  it('1D Tensor', () => {
+    const a = sm.tensor(new Float32Array([1, 0, 3, 2]))
+    const r = sm.argmax(a, 0)
+    expectArraysClose(r.toFloat32Array(), [2])
+  })
+  it('one element', () => {
+    const a = sm.tensor(new Float32Array([10]))
+    const r = sm.argmax(a, 0)
+    expectArraysClose(r.toFloat32Array(), [0])
+  })
+  it('1D Tensor', () => {
+    const n = THRESHOLD * 2
+    const values = new Float32Array(n)
+    for (let i = 0; i < n; i++) {
+      values[i] = i
+    }
+    const a = sm.tensor(values)
+    const r = sm.argmax(a, 0)
+    expectArraysClose(r.toFloat32Array(), n - 1)
+  })
+  it('3D Tensor, axis=-1', () => {
+    const n = THRESHOLD * 2
+    const values = new Float32Array(n)
+    for (let i = 0; i < n; i++) {
+      values[i] = i
+    }
+    const a = sm.tensor(values).reshape([1, 1, n])
+    const r = sm.argmax(a, -1)
+    expectArraysClose(r.toFloat32Array(), n - 1)
+  })
+  it('ignores NaNs', () => {
+    const a = sm.tensor(new Float32Array([0, 3, 5, NaN, 3]))
+    const r = sm.argmax(a, 0)
+    expectArraysClose(r.toFloat32Array(), [2])
+  })
+  /* TODO: FIX - CURRENTLY FAILS */
+  it('2D Tensor, axis=0', () => {
+    const a = sm.tensor(new Float32Array([3, -1, 0, 100, -7, 2])).reshape([2, 3])
+    const r = sm.argmax(a, 0)
+    expect(isShape(r, [3])).toBe(true)
+    expectArraysClose(r.toFloat32Array(), [1, 0, 1])
+  })
+  /* TODO: FIX - CURRENTLY FAILS (Throws C++ Exception)
+    it('6D Tensor, axis=0', () => {
+      const a = sm.tensor(new Float32Array([3, -1, 0, 100, -7, 2])).reshape([2, 1, 1, 1, 1, 3])
+      const r = sm.argmax(a, 0)
+      expect(isShape(r, [1, 1, 1, 1, 3])).toBe(true)
+      expectArraysClose(r.toFloat32Array(), [1, 0, 1])
+    })
+  */
+  /* TODO: FIX - CURRENTLY FAILS */
+  it('2D Tensor, axis=1', () => {
+    const a = sm.tensor(new Float32Array([3, 2, 5, 100, -7, 2])).reshape([2, 3])
+    expectArraysClose(sm.argmax(a, 1).toFloat32Array(), [2, 0])
+  })
+  it('2D Tensor, axis=-1', () => {
+    const a = sm.tensor(new Float32Array([3, 2, 5, 100, -7, 2])).reshape([2, 3])
+    expectArraysClose(sm.argmax(a, -1).toFloat32Array(), [2, 0])
+  })
+  /* TODO: unit tests for gradients */
+})

--- a/test/argmin.test.ts
+++ b/test/argmin.test.ts
@@ -1,0 +1,65 @@
+import { it, describe, expect } from 'bun:test'
+import * as sm from '@shumai/shumai'
+import { expectArraysClose, isShape } from './utils'
+
+const THRESHOLD = 30
+
+describe('argmin', () => {
+  it('1D Tensor', () => {
+    const a = sm.tensor(new Float32Array([1, 0, 3, 2]))
+    const r = sm.argmin(a, 0)
+    expectArraysClose(r.toFloat32Array(), [1])
+  })
+  it('one element', () => {
+    const a = sm.tensor(new Float32Array([10]))
+    const r = sm.argmin(a, 0)
+    expectArraysClose(r.toFloat32Array(), [0])
+  })
+  it('1D Tensor', () => {
+    const n = THRESHOLD * 2
+    const values = new Float32Array(n)
+    for (let i = 0; i < n; i++) {
+      values[i] = n - i
+    }
+    const a = sm.tensor(values)
+    const r = sm.argmin(a, 0)
+    expectArraysClose(r.toFloat32Array(), n - 1)
+  })
+  it('4D Tensor, axis=-1', () => {
+    const n = THRESHOLD * 2
+    const values = new Float32Array(n)
+    for (let i = 0; i < n; i++) {
+      values[i] = n - i
+    }
+    const a = sm.tensor(values).reshape([1, 1, 1, n])
+    const r = sm.argmin(a, -1)
+    expectArraysClose(r.toFloat32Array(), n - 1)
+  })
+  it('ignores NaNs', () => {
+    const a = sm.tensor(new Float32Array([5, 0, NaN, -1, 3]))
+    const r = sm.argmin(a, 0)
+    expectArraysClose(r.toFloat32Array(), [3])
+  })
+  it('3D Tensor, axis=-1; ignores NaNs', () => {
+    const a = sm.tensor(new Float32Array([5, 0, NaN, -1, 3])).reshape([1, 1, 5])
+    const r = sm.argmin(a, -1)
+    expectArraysClose(r.toFloat32Array(), [3])
+  })
+  /* TODO: FIX - CURRENTLY FAILS */
+  it('2D Tensor, axis=0', () => {
+    const a = sm.tensor(new Float32Array([3, -1, 0, 100, -7, 2])).reshape([2, 3])
+    const r = sm.argmin(a, 0)
+    expect(isShape(r, [3])).toBe(true)
+    expectArraysClose(r.toFloat32Array(), [0, 1, 0])
+  })
+  /* TODO: FIX - CURRENTLY FAILS */
+  it('2D Tensor, axis=1', () => {
+    const a = sm.tensor(new Float32Array([3, 2, 5, 100, -7, -8])).reshape([2, 3])
+    expectArraysClose(sm.argmin(a, 1).toFloat32Array(), [1, 2])
+  })
+  it('2D Tensor, axis=-1', () => {
+    const a = sm.tensor(new Float32Array([3, 2, 5, 100, -7, -8])).reshape([2, 3])
+    expectArraysClose(sm.argmin(a, -1).toFloat32Array(), [1, 2])
+  })
+  /* TODO: unit tests for gradients */
+})

--- a/test/cos.test.ts
+++ b/test/cos.test.ts
@@ -19,5 +19,5 @@ describe('cos', () => {
     expectArraysClose(r.toFloat32Array(), [Math.cos(4), NaN, Math.cos(0)])
   })
 
-  /* TODO: unit tests for gradients once supported */
+  /* TODO: unit tests for gradients */
 })

--- a/test/erf.test.ts
+++ b/test/erf.test.ts
@@ -33,5 +33,5 @@ describe('erf', () => {
     expectArraysClose(res.toFloat32Array(), [0.5204999, NaN, 0.0])
   })
 
-  /* TODO: unit tests for gradients once supported */
+  /* TODO: unit tests for gradients */
 })

--- a/test/flip.test.ts
+++ b/test/flip.test.ts
@@ -16,5 +16,5 @@ describe('flip', () => {
     expectArraysClose(r2.toFloat32Array(), [0, 1, 2, 12345678])
   })
 
-  /* TODO: unit tests for gradients once supported */
+  /* TODO: unit tests for gradients */
 })

--- a/test/greaterThan.test.ts
+++ b/test/greaterThan.test.ts
@@ -165,5 +165,5 @@ describe('greaterThan', () => {
     expectArraysClose(r.toFloat32Array(), [1, 0, 0, 0])
   })
 
-  /* TODO: unit tests for gradients once supported */
+  /* TODO: unit tests for gradients */
 })

--- a/test/greaterThan.test.ts
+++ b/test/greaterThan.test.ts
@@ -2,49 +2,41 @@ import { it, describe, expect } from 'bun:test'
 import * as sm from '@shumai/shumai'
 import { expectArraysClose, isShape } from './utils'
 
-describe('lessThan', () => {
+describe('greaterThan', () => {
   it('basic (1D Binary Tensor)', () => {
-    const a = sm.tensor(new Float32Array([0, 1, 0, 1]))
-    const b = sm.tensor(new Float32Array([1, 1, 1, 1]))
-    const r = a.lessThan(b)
-    expect(isShape(r, [4])).toBe(true)
-    expectArraysClose(r.toFloat32Array(), [1, 0, 1, 0])
-  })
-
-  it('basic (1D Tensor)', () => {
     let a = sm.tensor(new Float32Array([1, 4, 5])),
       b = sm.tensor(new Float32Array([2, 3, 5])),
-      r = sm.lessThan(a, b)
+      r = sm.greaterThan(a, b)
     expect(isShape(r, [3])).toBe(true)
-    expectArraysClose(r.toFloat32Array(), [1, 0, 0])
+    expectArraysClose(r.toFloat32Array(), [0, 1, 0])
 
-    a = sm.tensor(new Float32Array([2, 3, 4]))
-    b = sm.tensor(new Float32Array([2, 3, 4]))
-    r = a.lessThan(b)
+    a = sm.tensor(new Float32Array([2, 2, 2]))
+    b = sm.tensor(new Float32Array([2, 2, 2]))
+    r = a.greaterThan(b)
     expect(isShape(r, [3])).toBe(true)
     expectArraysClose(r.toFloat32Array(), [0, 0, 0])
 
-    a = sm.tensor(new Float32Array([0, 0]))
-    b = sm.tensor(new Float32Array([3, 3]))
-    r = a.lessThan(b)
+    a = sm.tensor(new Float32Array([3, 3]))
+    b = sm.tensor(new Float32Array([0, 0]))
+    r = a.greaterThan(b)
     expect(isShape(r, [2])).toBe(true)
     expectArraysClose(r.toFloat32Array(), [1, 1])
 
     a = sm.tensor(new Float32Array([1.1, 4.1, 5.1]))
     b = sm.tensor(new Float32Array([2.2, 3.2, 5.1]))
-    r = a.lessThan(b)
+    r = a.greaterThan(b)
     expect(isShape(r, [3])).toBe(true)
-    expectArraysClose(r.toFloat32Array(), [1, 0, 0])
+    expectArraysClose(r.toFloat32Array(), [0, 1, 0])
 
     a = sm.tensor(new Float32Array([2.31, 2.31, 2.31]))
     b = sm.tensor(new Float32Array([2.31, 2.31, 2.31]))
-    r = a.lessThan(b)
+    r = a.greaterThan(b)
     expect(isShape(r, [3])).toBe(true)
     expectArraysClose(r.toFloat32Array(), [0, 0, 0])
 
-    a = sm.tensor(new Float32Array([0.45, 0.123]))
-    b = sm.tensor(new Float32Array([3.123, 3.321]))
-    r = a.lessThan(b)
+    a = sm.tensor(new Float32Array([3.123, 3.321]))
+    b = sm.tensor(new Float32Array([0.45, 0.123]))
+    r = a.greaterThan(b)
     expect(isShape(r, [2])).toBe(true)
     expectArraysClose(r.toFloat32Array(), [1, 1])
   })
@@ -52,33 +44,34 @@ describe('lessThan', () => {
   it('1D Tensor with NaNs', () => {
     const a = sm.tensor(new Float32Array([1.1, NaN, 2.1]))
     const b = sm.tensor(new Float32Array([2.1, 3.1, NaN]))
-    const r = sm.lessThan(a, b)
+    const r = sm.greaterThan(a, b)
     expect(isShape(r, [3])).toBe(true)
-    expectArraysClose(r.toFloat32Array(), [1, 0, 0])
+    expectArraysClose(r.toFloat32Array(), [0, 0, 0])
   })
 
+  /* TODO: FIX - CURRENTLY FAILS */
   it('2D Tensor', () => {
-    let a = sm.tensor(new Float32Array([1, 4, 5, 8, 9, 12])).reshape([2, 3]),
+    let a = sm.tensor(new Float32Array([1, 4, 5, 8, 9, 11])).reshape([2, 3]),
       b = sm.tensor(new Float32Array([2, 3, 6, 7, 10, 11])).reshape([2, 3]),
-      r = sm.lessThan(a, b)
+      r = sm.greaterThan(a, b)
     expect(isShape(r, [2, 3])).toBe(true)
-    expectArraysClose(r.toFloat32Array(), [1, 0, 1, 0, 1, 0])
+    expectArraysClose(r.toFloat32Array(), [0, 1, 0, 1, 0, 0])
 
     a = sm.tensor(new Float32Array([0, 0, 1, 1])).reshape([2, 2])
     b = sm.tensor(new Float32Array([0, 0, 1, 1])).reshape([2, 2])
-    r = a.lessThan(b)
+    r = a.greaterThan(b)
     expect(isShape(r, [2, 2])).toBe(true)
     expectArraysClose(r.toFloat32Array(), [0, 0, 0, 0])
 
-    a = sm.tensor(new Float32Array([1.1, 4.1, 5.1, 8.1, 9.1, 12.1])).reshape([2, 3])
+    a = sm.tensor(new Float32Array([1.1, 4.1, 5.1, 8.1, 9.1, 11.1])).reshape([2, 3])
     b = sm.tensor(new Float32Array([2.1, 3.1, 6.1, 7.1, 10.1, 11.1])).reshape([2, 3])
-    r = sm.lessThan(a, b)
+    r = sm.greaterThan(a, b)
     expect(isShape(r, [2, 3])).toBe(true)
-    expectArraysClose(r.toFloat32Array(), [1, 0, 1, 0, 1, 0])
+    expectArraysClose(r.toFloat32Array(), [0, 1, 0, 1, 0, 0])
 
     a = sm.tensor(new Float32Array([0.2, 0.2, 1.2, 1.2])).reshape([2, 2])
     b = sm.tensor(new Float32Array([0.2, 0.2, 1.2, 1.2])).reshape([2, 2])
-    r = sm.lessThan(a, b)
+    r = sm.greaterThan(a, b)
     expect(isShape(r, [2, 2])).toBe(true)
     expectArraysClose(r.toFloat32Array(), [0, 0, 0, 0])
   })
@@ -86,33 +79,33 @@ describe('lessThan', () => {
   it('2D Tensor with NaNs', () => {
     const a = sm.tensor(new Float32Array([1.1, NaN, 0.1, NaN])).reshape([2, 2])
     const b = sm.tensor(new Float32Array([0.1, NaN, 1.1, NaN])).reshape([2, 2])
-    const r = sm.lessThan(a, b)
+    const r = sm.greaterThan(a, b)
     expect(isShape(r, [2, 2])).toBe(true)
-    expectArraysClose(r.toFloat32Array(), [0, 0, 1, 0])
+    expectArraysClose(r.toFloat32Array(), [1, 0, 0, 0])
   })
 
   it('3D Tensor', () => {
-    let a = sm.tensor(new Float32Array([1, 4, 5, 8, 9, 12])).reshape([2, 3, 1]),
+    let a = sm.tensor(new Float32Array([1, 4, 5, 8, 9, 11])).reshape([2, 3, 1]),
       b = sm.tensor(new Float32Array([2, 3, 6, 7, 10, 11])).reshape([2, 3, 1]),
-      r = sm.lessThan(a, b)
+      r = sm.greaterThan(a, b)
     expect(isShape(r, [2, 3, 1])).toBe(true)
-    expectArraysClose(r.toFloat32Array(), [1, 0, 1, 0, 1, 0])
+    expectArraysClose(r.toFloat32Array(), [0, 1, 0, 1, 0, 0])
 
     a = sm.tensor(new Float32Array([0, 0, 0, 1, 1, 1])).reshape([2, 3, 1])
     b = sm.tensor(new Float32Array([0, 0, 0, 1, 1, 1])).reshape([2, 3, 1])
-    r = sm.lessThan(a, b)
+    r = sm.greaterThan(a, b)
     expect(isShape(r, [2, 3, 1])).toBe(true)
     expectArraysClose(r.toFloat32Array(), [0, 0, 0, 0, 0, 0])
 
-    a = sm.tensor(new Float32Array([1.1, 4.1, 5.1, 8.1, 9.1, 12.1])).reshape([2, 3, 1])
+    a = sm.tensor(new Float32Array([1.1, 4.1, 5.1, 8.1, 9.1, 11.1])).reshape([2, 3, 1])
     b = sm.tensor(new Float32Array([2.1, 3.1, 6.1, 7.1, 10.1, 11.1])).reshape([2, 3, 1])
-    r = sm.lessThan(a, b)
+    r = sm.greaterThan(a, b)
     expect(isShape(r, [2, 3, 1])).toBe(true)
-    expectArraysClose(r.toFloat32Array(), [1, 0, 1, 0, 1, 0])
+    expectArraysClose(r.toFloat32Array(), [0, 1, 0, 1, 0, 0])
 
-    a = sm.tensor(new Float32Array([0.1, 0.1, 0.1, 1.1, 1.1, 1.0])).reshape([2, 3, 1])
+    a = sm.tensor(new Float32Array([0.1, 0.1, 0.1, 1.1, 1.1, 1.2])).reshape([2, 3, 1])
     b = sm.tensor(new Float32Array([0.1, 0.1, 0.1, 1.1, 1.1, 1.1])).reshape([2, 3, 1])
-    r = sm.lessThan(a, b)
+    r = sm.greaterThan(a, b)
     expect(isShape(r, [2, 3, 1])).toBe(true)
     expectArraysClose(r.toFloat32Array(), [0, 0, 0, 0, 0, 1])
   })
@@ -120,45 +113,46 @@ describe('lessThan', () => {
   it('3D Tensor with NaNs', () => {
     const a = sm.tensor(new Float32Array([1.1, NaN, 1.1, 0.1, 0.1, 0.1])).reshape([2, 3, 1])
     const b = sm.tensor(new Float32Array([0.1, 0.1, 1.1, 1.1, 0.1, NaN])).reshape([2, 3, 1])
-    const r = a.lessThan(b)
+    const r = a.greaterThan(b)
     expect(isShape(r, [2, 3, 1])).toBe(true)
-    expectArraysClose(r.toFloat32Array(), [0, 0, 0, 1, 0, 0])
+    expectArraysClose(r.toFloat32Array(), [1, 0, 0, 0, 0, 0])
   })
 
+  /* TODO: FIX - CURRENTLY FAILS */
   it('4D Tensor', () => {
     let a = sm.tensor(new Float32Array([1, 4, 5, 8])).reshape([2, 2, 1, 1]),
-      b = sm.tensor(new Float32Array([2, 3, 6, 7])).reshape([2, 2, 1, 1]),
-      r = sm.lessThan(a, b)
+      b = sm.tensor(new Float32Array([2, 3, 6, 8])).reshape([2, 2, 1, 1]),
+      r = sm.greaterThan(a, b)
     expect(isShape(r, [2, 2, 1, 1])).toBe(true)
-    expectArraysClose(r.toFloat32Array(), [1, 0, 1, 0])
+    expectArraysClose(r.toFloat32Array(), [0, 1, 0, 0])
 
     a = sm.tensor(new Float32Array([0, 1, 2, 3])).reshape([2, 2, 1, 1])
     b = sm.tensor(new Float32Array([0, 1, 2, 3])).reshape([2, 2, 1, 1])
-    r = sm.lessThan(a, b)
+    r = sm.greaterThan(a, b)
     expect(isShape(r, [2, 2, 1, 1])).toBe(true)
     expectArraysClose(r.toFloat32Array(), [0, 0, 0, 0])
 
-    a = sm.tensor(new Float32Array([1, 1, 1, 1])).reshape([2, 2, 1, 1])
-    b = sm.tensor(new Float32Array([2, 2, 2, 2])).reshape([2, 2, 1, 1])
-    r = sm.lessThan(a, b)
+    a = sm.tensor(new Float32Array([2, 2, 2, 2])).reshape([2, 2, 1, 1])
+    b = sm.tensor(new Float32Array([1, 1, 1, 1])).reshape([2, 2, 1, 1])
+    r = sm.greaterThan(a, b)
     expect(isShape(r, [2, 2, 1, 1])).toBe(true)
     expectArraysClose(r.toFloat32Array(), [1, 1, 1, 1])
 
     a = sm.tensor(new Float32Array([1.1, 4.1, 5.1, 8.1])).reshape([2, 2, 1, 1])
-    b = sm.tensor(new Float32Array([2.1, 3.1, 6.1, 7.1])).reshape([2, 2, 1, 1])
-    r = sm.lessThan(a, b)
+    b = sm.tensor(new Float32Array([2.1, 3.1, 6.1, 8.1])).reshape([2, 2, 1, 1])
+    r = sm.greaterThan(a, b)
     expect(isShape(r, [2, 2, 1, 1])).toBe(true)
-    expectArraysClose(r.toFloat32Array(), [1, 0, 1, 0])
+    expectArraysClose(r.toFloat32Array(), [0, 1, 0, 0])
 
     a = sm.tensor(new Float32Array([0.1, 1.1, 2.2, 3.3])).reshape([2, 2, 1, 1])
     b = sm.tensor(new Float32Array([0.1, 1.1, 2.2, 3.3])).reshape([2, 2, 1, 1])
-    r = sm.lessThan(a, b)
+    r = sm.greaterThan(a, b)
     expect(isShape(r, [2, 2, 1, 1])).toBe(true)
     expectArraysClose(r.toFloat32Array(), [0, 0, 0, 0])
 
-    a = sm.tensor(new Float32Array([0.1, 0.1, 0.1, 0.1])).reshape([2, 2, 1, 1])
-    b = sm.tensor(new Float32Array([1.1, 1.1, 1.1, 1.1])).reshape([2, 2, 1, 1])
-    r = sm.lessThan(a, b)
+    a = sm.tensor(new Float32Array([1.1, 1.1, 1.1, 1.1])).reshape([2, 2, 1, 1])
+    b = sm.tensor(new Float32Array([0.1, 0.1, 0.1, 0.1])).reshape([2, 2, 1, 1])
+    r = sm.greaterThan(a, b)
     expect(isShape(r, [2, 2, 1, 1])).toBe(true)
     expectArraysClose(r.toFloat32Array(), [1, 1, 1, 1])
   })
@@ -166,9 +160,9 @@ describe('lessThan', () => {
   it('4D Tensor with NaNs', () => {
     const a = sm.tensor(new Float32Array([1.1, NaN, 0.1, 0.1])).reshape([2, 2, 1, 1])
     const b = sm.tensor(new Float32Array([0.1, 1.1, 1.1, NaN])).reshape([2, 2, 1, 1])
-    const r = a.lessThan(b)
+    const r = a.greaterThan(b)
     expect(isShape(r, [2, 2, 1, 1])).toBe(true)
-    expectArraysClose(r.toFloat32Array(), [0, 0, 1, 0])
+    expectArraysClose(r.toFloat32Array(), [1, 0, 0, 0])
   })
 
   /* TODO: unit tests for gradients once supported */

--- a/test/greaterThanEqual.test.ts
+++ b/test/greaterThanEqual.test.ts
@@ -2,173 +2,165 @@ import { it, describe, expect } from 'bun:test'
 import * as sm from '@shumai/shumai'
 import { expectArraysClose, isShape } from './utils'
 
-describe('lessThan', () => {
-  it('basic (1D Binary Tensor)', () => {
-    const a = sm.tensor(new Float32Array([0, 1, 0, 1]))
-    const b = sm.tensor(new Float32Array([1, 1, 1, 1]))
-    const r = a.lessThan(b)
-    expect(isShape(r, [4])).toBe(true)
-    expectArraysClose(r.toFloat32Array(), [1, 0, 1, 0])
-  })
-
+describe('greaterThanEqual', () => {
   it('basic (1D Tensor)', () => {
     let a = sm.tensor(new Float32Array([1, 4, 5])),
       b = sm.tensor(new Float32Array([2, 3, 5])),
-      r = sm.lessThan(a, b)
+      r = sm.greaterThanEqual(a, b)
     expect(isShape(r, [3])).toBe(true)
-    expectArraysClose(r.toFloat32Array(), [1, 0, 0])
+    expectArraysClose(r.toFloat32Array(), [0, 1, 1])
 
-    a = sm.tensor(new Float32Array([2, 3, 4]))
-    b = sm.tensor(new Float32Array([2, 3, 4]))
-    r = a.lessThan(b)
+    a = sm.tensor(new Float32Array([2, 2, 2]))
+    b = sm.tensor(new Float32Array([2, 2, 2]))
+    r = a.greaterThanEqual(b)
     expect(isShape(r, [3])).toBe(true)
-    expectArraysClose(r.toFloat32Array(), [0, 0, 0])
+    expectArraysClose(r.toFloat32Array(), [1, 1, 1])
 
     a = sm.tensor(new Float32Array([0, 0]))
     b = sm.tensor(new Float32Array([3, 3]))
-    r = a.lessThan(b)
+    r = a.greaterThanEqual(b)
     expect(isShape(r, [2])).toBe(true)
-    expectArraysClose(r.toFloat32Array(), [1, 1])
+    expectArraysClose(r.toFloat32Array(), [0, 0])
 
     a = sm.tensor(new Float32Array([1.1, 4.1, 5.1]))
     b = sm.tensor(new Float32Array([2.2, 3.2, 5.1]))
-    r = a.lessThan(b)
+    r = a.greaterThanEqual(b)
     expect(isShape(r, [3])).toBe(true)
-    expectArraysClose(r.toFloat32Array(), [1, 0, 0])
+    expectArraysClose(r.toFloat32Array(), [0, 1, 1])
 
     a = sm.tensor(new Float32Array([2.31, 2.31, 2.31]))
     b = sm.tensor(new Float32Array([2.31, 2.31, 2.31]))
-    r = a.lessThan(b)
+    r = a.greaterThanEqual(b)
     expect(isShape(r, [3])).toBe(true)
-    expectArraysClose(r.toFloat32Array(), [0, 0, 0])
+    expectArraysClose(r.toFloat32Array(), [1, 1, 1])
 
     a = sm.tensor(new Float32Array([0.45, 0.123]))
     b = sm.tensor(new Float32Array([3.123, 3.321]))
-    r = a.lessThan(b)
+    r = a.greaterThanEqual(b)
     expect(isShape(r, [2])).toBe(true)
-    expectArraysClose(r.toFloat32Array(), [1, 1])
+    expectArraysClose(r.toFloat32Array(), [0, 0])
   })
 
   it('1D Tensor with NaNs', () => {
     const a = sm.tensor(new Float32Array([1.1, NaN, 2.1]))
     const b = sm.tensor(new Float32Array([2.1, 3.1, NaN]))
-    const r = sm.lessThan(a, b)
+    const r = sm.greaterThanEqual(a, b)
     expect(isShape(r, [3])).toBe(true)
-    expectArraysClose(r.toFloat32Array(), [1, 0, 0])
+    expectArraysClose(r.toFloat32Array(), [0, 0, 0])
   })
 
   it('2D Tensor', () => {
     let a = sm.tensor(new Float32Array([1, 4, 5, 8, 9, 12])).reshape([2, 3]),
       b = sm.tensor(new Float32Array([2, 3, 6, 7, 10, 11])).reshape([2, 3]),
-      r = sm.lessThan(a, b)
+      r = sm.greaterThanEqual(a, b)
     expect(isShape(r, [2, 3])).toBe(true)
-    expectArraysClose(r.toFloat32Array(), [1, 0, 1, 0, 1, 0])
+    expectArraysClose(r.toFloat32Array(), [0, 1, 0, 1, 0, 1])
 
     a = sm.tensor(new Float32Array([0, 0, 1, 1])).reshape([2, 2])
     b = sm.tensor(new Float32Array([0, 0, 1, 1])).reshape([2, 2])
-    r = a.lessThan(b)
+    r = a.greaterThanEqual(b)
     expect(isShape(r, [2, 2])).toBe(true)
-    expectArraysClose(r.toFloat32Array(), [0, 0, 0, 0])
+    expectArraysClose(r.toFloat32Array(), [1, 1, 1, 1])
 
     a = sm.tensor(new Float32Array([1.1, 4.1, 5.1, 8.1, 9.1, 12.1])).reshape([2, 3])
     b = sm.tensor(new Float32Array([2.1, 3.1, 6.1, 7.1, 10.1, 11.1])).reshape([2, 3])
-    r = sm.lessThan(a, b)
+    r = sm.greaterThanEqual(a, b)
     expect(isShape(r, [2, 3])).toBe(true)
-    expectArraysClose(r.toFloat32Array(), [1, 0, 1, 0, 1, 0])
+    expectArraysClose(r.toFloat32Array(), [0, 1, 0, 1, 0, 1])
 
     a = sm.tensor(new Float32Array([0.2, 0.2, 1.2, 1.2])).reshape([2, 2])
     b = sm.tensor(new Float32Array([0.2, 0.2, 1.2, 1.2])).reshape([2, 2])
-    r = sm.lessThan(a, b)
+    r = sm.greaterThanEqual(a, b)
     expect(isShape(r, [2, 2])).toBe(true)
-    expectArraysClose(r.toFloat32Array(), [0, 0, 0, 0])
+    expectArraysClose(r.toFloat32Array(), [1, 1, 1, 1])
   })
 
   it('2D Tensor with NaNs', () => {
     const a = sm.tensor(new Float32Array([1.1, NaN, 0.1, NaN])).reshape([2, 2])
     const b = sm.tensor(new Float32Array([0.1, NaN, 1.1, NaN])).reshape([2, 2])
-    const r = sm.lessThan(a, b)
+    const r = sm.greaterThanEqual(a, b)
     expect(isShape(r, [2, 2])).toBe(true)
-    expectArraysClose(r.toFloat32Array(), [0, 0, 1, 0])
+    expectArraysClose(r.toFloat32Array(), [1, 0, 0, 0])
   })
 
   it('3D Tensor', () => {
     let a = sm.tensor(new Float32Array([1, 4, 5, 8, 9, 12])).reshape([2, 3, 1]),
       b = sm.tensor(new Float32Array([2, 3, 6, 7, 10, 11])).reshape([2, 3, 1]),
-      r = sm.lessThan(a, b)
+      r = sm.greaterThanEqual(a, b)
     expect(isShape(r, [2, 3, 1])).toBe(true)
-    expectArraysClose(r.toFloat32Array(), [1, 0, 1, 0, 1, 0])
+    expectArraysClose(r.toFloat32Array(), [0, 1, 0, 1, 0, 1])
 
     a = sm.tensor(new Float32Array([0, 0, 0, 1, 1, 1])).reshape([2, 3, 1])
     b = sm.tensor(new Float32Array([0, 0, 0, 1, 1, 1])).reshape([2, 3, 1])
-    r = sm.lessThan(a, b)
+    r = sm.greaterThanEqual(a, b)
     expect(isShape(r, [2, 3, 1])).toBe(true)
-    expectArraysClose(r.toFloat32Array(), [0, 0, 0, 0, 0, 0])
+    expectArraysClose(r.toFloat32Array(), [1, 1, 1, 1, 1, 1])
 
     a = sm.tensor(new Float32Array([1.1, 4.1, 5.1, 8.1, 9.1, 12.1])).reshape([2, 3, 1])
     b = sm.tensor(new Float32Array([2.1, 3.1, 6.1, 7.1, 10.1, 11.1])).reshape([2, 3, 1])
-    r = sm.lessThan(a, b)
+    r = sm.greaterThanEqual(a, b)
     expect(isShape(r, [2, 3, 1])).toBe(true)
-    expectArraysClose(r.toFloat32Array(), [1, 0, 1, 0, 1, 0])
+    expectArraysClose(r.toFloat32Array(), [0, 1, 0, 1, 0, 1])
 
-    a = sm.tensor(new Float32Array([0.1, 0.1, 0.1, 1.1, 1.1, 1.0])).reshape([2, 3, 1])
+    a = sm.tensor(new Float32Array([0.1, 0.1, 0.1, 1.1, 1.1, 1.2])).reshape([2, 3, 1])
     b = sm.tensor(new Float32Array([0.1, 0.1, 0.1, 1.1, 1.1, 1.1])).reshape([2, 3, 1])
-    r = sm.lessThan(a, b)
+    r = sm.greaterThanEqual(a, b)
     expect(isShape(r, [2, 3, 1])).toBe(true)
-    expectArraysClose(r.toFloat32Array(), [0, 0, 0, 0, 0, 1])
+    expectArraysClose(r.toFloat32Array(), [1, 1, 1, 1, 1, 1])
   })
 
   it('3D Tensor with NaNs', () => {
     const a = sm.tensor(new Float32Array([1.1, NaN, 1.1, 0.1, 0.1, 0.1])).reshape([2, 3, 1])
     const b = sm.tensor(new Float32Array([0.1, 0.1, 1.1, 1.1, 0.1, NaN])).reshape([2, 3, 1])
-    const r = a.lessThan(b)
+    const r = a.greaterThanEqual(b)
     expect(isShape(r, [2, 3, 1])).toBe(true)
-    expectArraysClose(r.toFloat32Array(), [0, 0, 0, 1, 0, 0])
+    expectArraysClose(r.toFloat32Array(), [1, 0, 1, 0, 1, 0])
   })
 
   it('4D Tensor', () => {
     let a = sm.tensor(new Float32Array([1, 4, 5, 8])).reshape([2, 2, 1, 1]),
       b = sm.tensor(new Float32Array([2, 3, 6, 7])).reshape([2, 2, 1, 1]),
-      r = sm.lessThan(a, b)
+      r = sm.greaterThanEqual(a, b)
     expect(isShape(r, [2, 2, 1, 1])).toBe(true)
-    expectArraysClose(r.toFloat32Array(), [1, 0, 1, 0])
+    expectArraysClose(r.toFloat32Array(), [0, 1, 0, 1])
 
     a = sm.tensor(new Float32Array([0, 1, 2, 3])).reshape([2, 2, 1, 1])
     b = sm.tensor(new Float32Array([0, 1, 2, 3])).reshape([2, 2, 1, 1])
-    r = sm.lessThan(a, b)
+    r = sm.greaterThanEqual(a, b)
     expect(isShape(r, [2, 2, 1, 1])).toBe(true)
-    expectArraysClose(r.toFloat32Array(), [0, 0, 0, 0])
+    expectArraysClose(r.toFloat32Array(), [1, 1, 1, 1])
 
     a = sm.tensor(new Float32Array([1, 1, 1, 1])).reshape([2, 2, 1, 1])
     b = sm.tensor(new Float32Array([2, 2, 2, 2])).reshape([2, 2, 1, 1])
-    r = sm.lessThan(a, b)
-    expect(isShape(r, [2, 2, 1, 1])).toBe(true)
-    expectArraysClose(r.toFloat32Array(), [1, 1, 1, 1])
-
-    a = sm.tensor(new Float32Array([1.1, 4.1, 5.1, 8.1])).reshape([2, 2, 1, 1])
-    b = sm.tensor(new Float32Array([2.1, 3.1, 6.1, 7.1])).reshape([2, 2, 1, 1])
-    r = sm.lessThan(a, b)
-    expect(isShape(r, [2, 2, 1, 1])).toBe(true)
-    expectArraysClose(r.toFloat32Array(), [1, 0, 1, 0])
-
-    a = sm.tensor(new Float32Array([0.1, 1.1, 2.2, 3.3])).reshape([2, 2, 1, 1])
-    b = sm.tensor(new Float32Array([0.1, 1.1, 2.2, 3.3])).reshape([2, 2, 1, 1])
-    r = sm.lessThan(a, b)
+    r = sm.greaterThanEqual(a, b)
     expect(isShape(r, [2, 2, 1, 1])).toBe(true)
     expectArraysClose(r.toFloat32Array(), [0, 0, 0, 0])
 
-    a = sm.tensor(new Float32Array([0.1, 0.1, 0.1, 0.1])).reshape([2, 2, 1, 1])
-    b = sm.tensor(new Float32Array([1.1, 1.1, 1.1, 1.1])).reshape([2, 2, 1, 1])
-    r = sm.lessThan(a, b)
+    a = sm.tensor(new Float32Array([1.1, 4.1, 5.1, 8.1])).reshape([2, 2, 1, 1])
+    b = sm.tensor(new Float32Array([2.1, 3.1, 6.1, 7.1])).reshape([2, 2, 1, 1])
+    r = sm.greaterThanEqual(a, b)
+    expect(isShape(r, [2, 2, 1, 1])).toBe(true)
+    expectArraysClose(r.toFloat32Array(), [0, 1, 0, 1])
+
+    a = sm.tensor(new Float32Array([0.1, 1.1, 2.2, 3.3])).reshape([2, 2, 1, 1])
+    b = sm.tensor(new Float32Array([0.1, 1.1, 2.2, 3.3])).reshape([2, 2, 1, 1])
+    r = sm.greaterThanEqual(a, b)
     expect(isShape(r, [2, 2, 1, 1])).toBe(true)
     expectArraysClose(r.toFloat32Array(), [1, 1, 1, 1])
+
+    a = sm.tensor(new Float32Array([0.1, 0.1, 0.1, 0.1])).reshape([2, 2, 1, 1])
+    b = sm.tensor(new Float32Array([1.1, 1.1, 1.1, 1.1])).reshape([2, 2, 1, 1])
+    r = sm.greaterThanEqual(a, b)
+    expect(isShape(r, [2, 2, 1, 1])).toBe(true)
+    expectArraysClose(r.toFloat32Array(), [0, 0, 0, 0])
   })
 
   it('4D Tensor with NaNs', () => {
     const a = sm.tensor(new Float32Array([1.1, NaN, 0.1, 0.1])).reshape([2, 2, 1, 1])
     const b = sm.tensor(new Float32Array([0.1, 1.1, 1.1, NaN])).reshape([2, 2, 1, 1])
-    const r = a.lessThan(b)
+    const r = a.greaterThanEqual(b)
     expect(isShape(r, [2, 2, 1, 1])).toBe(true)
-    expectArraysClose(r.toFloat32Array(), [0, 0, 1, 0])
+    expectArraysClose(r.toFloat32Array(), [1, 0, 0, 0])
   })
 
   /* TODO: unit tests for gradients once supported */

--- a/test/greaterThanEqual.test.ts
+++ b/test/greaterThanEqual.test.ts
@@ -163,5 +163,5 @@ describe('greaterThanEqual', () => {
     expectArraysClose(r.toFloat32Array(), [1, 0, 0, 0])
   })
 
-  /* TODO: unit tests for gradients once supported */
+  /* TODO: unit tests for gradients */
 })

--- a/test/isinf.test.ts
+++ b/test/isinf.test.ts
@@ -17,5 +17,5 @@ describe('isinf', () => {
       expectArraysClose(r.toFloat32Array(), [0, 1, 1, 0, 0])
     })
   */
-  /* TODO: unit tests for gradients once supported */
+  /* TODO: unit tests for gradients */
 })

--- a/test/isnan.test.ts
+++ b/test/isnan.test.ts
@@ -17,5 +17,5 @@ describe('isnan', () => {
     expectArraysClose(r.toFloat32Array(), [1, 0, 0, 0, 0])
   })
 
-  /* TODO: unit tests for gradients once supported */
+  /* TODO: unit tests for gradients */
 })

--- a/test/lessThan.test.ts
+++ b/test/lessThan.test.ts
@@ -171,5 +171,5 @@ describe('lessThan', () => {
     expectArraysClose(r.toFloat32Array(), [0, 0, 1, 0])
   })
 
-  /* TODO: unit tests for gradients once supported */
+  /* TODO: unit tests for gradients */
 })

--- a/test/lessThanEqual.test.ts
+++ b/test/lessThanEqual.test.ts
@@ -2,49 +2,41 @@ import { it, describe, expect } from 'bun:test'
 import * as sm from '@shumai/shumai'
 import { expectArraysClose, isShape } from './utils'
 
-describe('lessThan', () => {
-  it('basic (1D Binary Tensor)', () => {
-    const a = sm.tensor(new Float32Array([0, 1, 0, 1]))
-    const b = sm.tensor(new Float32Array([1, 1, 1, 1]))
-    const r = a.lessThan(b)
-    expect(isShape(r, [4])).toBe(true)
-    expectArraysClose(r.toFloat32Array(), [1, 0, 1, 0])
-  })
-
+describe('lessThanEqual', () => {
   it('basic (1D Tensor)', () => {
     let a = sm.tensor(new Float32Array([1, 4, 5])),
       b = sm.tensor(new Float32Array([2, 3, 5])),
-      r = sm.lessThan(a, b)
+      r = sm.lessThanEqual(a, b)
     expect(isShape(r, [3])).toBe(true)
-    expectArraysClose(r.toFloat32Array(), [1, 0, 0])
+    expectArraysClose(r.toFloat32Array(), [1, 0, 1])
 
-    a = sm.tensor(new Float32Array([2, 3, 4]))
-    b = sm.tensor(new Float32Array([2, 3, 4]))
-    r = a.lessThan(b)
+    a = sm.tensor(new Float32Array([2, 2, 2]))
+    b = sm.tensor(new Float32Array([2, 2, 2]))
+    r = a.lessThanEqual(b)
     expect(isShape(r, [3])).toBe(true)
-    expectArraysClose(r.toFloat32Array(), [0, 0, 0])
+    expectArraysClose(r.toFloat32Array(), [1, 1, 1])
 
     a = sm.tensor(new Float32Array([0, 0]))
     b = sm.tensor(new Float32Array([3, 3]))
-    r = a.lessThan(b)
+    r = a.lessThanEqual(b)
     expect(isShape(r, [2])).toBe(true)
     expectArraysClose(r.toFloat32Array(), [1, 1])
 
     a = sm.tensor(new Float32Array([1.1, 4.1, 5.1]))
     b = sm.tensor(new Float32Array([2.2, 3.2, 5.1]))
-    r = a.lessThan(b)
+    r = a.lessThanEqual(b)
     expect(isShape(r, [3])).toBe(true)
-    expectArraysClose(r.toFloat32Array(), [1, 0, 0])
+    expectArraysClose(r.toFloat32Array(), [1, 0, 1])
 
     a = sm.tensor(new Float32Array([2.31, 2.31, 2.31]))
     b = sm.tensor(new Float32Array([2.31, 2.31, 2.31]))
-    r = a.lessThan(b)
+    r = a.lessThanEqual(b)
     expect(isShape(r, [3])).toBe(true)
-    expectArraysClose(r.toFloat32Array(), [0, 0, 0])
+    expectArraysClose(r.toFloat32Array(), [1, 1, 1])
 
     a = sm.tensor(new Float32Array([0.45, 0.123]))
     b = sm.tensor(new Float32Array([3.123, 3.321]))
-    r = a.lessThan(b)
+    r = a.lessThanEqual(b)
     expect(isShape(r, [2])).toBe(true)
     expectArraysClose(r.toFloat32Array(), [1, 1])
   })
@@ -52,7 +44,7 @@ describe('lessThan', () => {
   it('1D Tensor with NaNs', () => {
     const a = sm.tensor(new Float32Array([1.1, NaN, 2.1]))
     const b = sm.tensor(new Float32Array([2.1, 3.1, NaN]))
-    const r = sm.lessThan(a, b)
+    const r = sm.lessThanEqual(a, b)
     expect(isShape(r, [3])).toBe(true)
     expectArraysClose(r.toFloat32Array(), [1, 0, 0])
   })
@@ -60,33 +52,33 @@ describe('lessThan', () => {
   it('2D Tensor', () => {
     let a = sm.tensor(new Float32Array([1, 4, 5, 8, 9, 12])).reshape([2, 3]),
       b = sm.tensor(new Float32Array([2, 3, 6, 7, 10, 11])).reshape([2, 3]),
-      r = sm.lessThan(a, b)
+      r = sm.lessThanEqual(a, b)
     expect(isShape(r, [2, 3])).toBe(true)
     expectArraysClose(r.toFloat32Array(), [1, 0, 1, 0, 1, 0])
 
     a = sm.tensor(new Float32Array([0, 0, 1, 1])).reshape([2, 2])
     b = sm.tensor(new Float32Array([0, 0, 1, 1])).reshape([2, 2])
-    r = a.lessThan(b)
+    r = a.lessThanEqual(b)
     expect(isShape(r, [2, 2])).toBe(true)
-    expectArraysClose(r.toFloat32Array(), [0, 0, 0, 0])
+    expectArraysClose(r.toFloat32Array(), [1, 1, 1, 1])
 
     a = sm.tensor(new Float32Array([1.1, 4.1, 5.1, 8.1, 9.1, 12.1])).reshape([2, 3])
     b = sm.tensor(new Float32Array([2.1, 3.1, 6.1, 7.1, 10.1, 11.1])).reshape([2, 3])
-    r = sm.lessThan(a, b)
+    r = sm.lessThanEqual(a, b)
     expect(isShape(r, [2, 3])).toBe(true)
     expectArraysClose(r.toFloat32Array(), [1, 0, 1, 0, 1, 0])
 
     a = sm.tensor(new Float32Array([0.2, 0.2, 1.2, 1.2])).reshape([2, 2])
     b = sm.tensor(new Float32Array([0.2, 0.2, 1.2, 1.2])).reshape([2, 2])
-    r = sm.lessThan(a, b)
+    r = sm.lessThanEqual(a, b)
     expect(isShape(r, [2, 2])).toBe(true)
-    expectArraysClose(r.toFloat32Array(), [0, 0, 0, 0])
+    expectArraysClose(r.toFloat32Array(), [1, 1, 1, 1])
   })
 
   it('2D Tensor with NaNs', () => {
     const a = sm.tensor(new Float32Array([1.1, NaN, 0.1, NaN])).reshape([2, 2])
     const b = sm.tensor(new Float32Array([0.1, NaN, 1.1, NaN])).reshape([2, 2])
-    const r = sm.lessThan(a, b)
+    const r = sm.lessThanEqual(a, b)
     expect(isShape(r, [2, 2])).toBe(true)
     expectArraysClose(r.toFloat32Array(), [0, 0, 1, 0])
   })
@@ -94,71 +86,71 @@ describe('lessThan', () => {
   it('3D Tensor', () => {
     let a = sm.tensor(new Float32Array([1, 4, 5, 8, 9, 12])).reshape([2, 3, 1]),
       b = sm.tensor(new Float32Array([2, 3, 6, 7, 10, 11])).reshape([2, 3, 1]),
-      r = sm.lessThan(a, b)
+      r = sm.lessThanEqual(a, b)
     expect(isShape(r, [2, 3, 1])).toBe(true)
     expectArraysClose(r.toFloat32Array(), [1, 0, 1, 0, 1, 0])
 
     a = sm.tensor(new Float32Array([0, 0, 0, 1, 1, 1])).reshape([2, 3, 1])
     b = sm.tensor(new Float32Array([0, 0, 0, 1, 1, 1])).reshape([2, 3, 1])
-    r = sm.lessThan(a, b)
+    r = sm.lessThanEqual(a, b)
     expect(isShape(r, [2, 3, 1])).toBe(true)
-    expectArraysClose(r.toFloat32Array(), [0, 0, 0, 0, 0, 0])
+    expectArraysClose(r.toFloat32Array(), [1, 1, 1, 1, 1, 1])
 
     a = sm.tensor(new Float32Array([1.1, 4.1, 5.1, 8.1, 9.1, 12.1])).reshape([2, 3, 1])
     b = sm.tensor(new Float32Array([2.1, 3.1, 6.1, 7.1, 10.1, 11.1])).reshape([2, 3, 1])
-    r = sm.lessThan(a, b)
+    r = sm.lessThanEqual(a, b)
     expect(isShape(r, [2, 3, 1])).toBe(true)
     expectArraysClose(r.toFloat32Array(), [1, 0, 1, 0, 1, 0])
 
-    a = sm.tensor(new Float32Array([0.1, 0.1, 0.1, 1.1, 1.1, 1.0])).reshape([2, 3, 1])
+    a = sm.tensor(new Float32Array([0.1, 0.1, 0.1, 1.1, 1.1, 1.2])).reshape([2, 3, 1])
     b = sm.tensor(new Float32Array([0.1, 0.1, 0.1, 1.1, 1.1, 1.1])).reshape([2, 3, 1])
-    r = sm.lessThan(a, b)
+    r = sm.lessThanEqual(a, b)
     expect(isShape(r, [2, 3, 1])).toBe(true)
-    expectArraysClose(r.toFloat32Array(), [0, 0, 0, 0, 0, 1])
+    expectArraysClose(r.toFloat32Array(), [1, 1, 1, 1, 1, 0])
   })
 
   it('3D Tensor with NaNs', () => {
     const a = sm.tensor(new Float32Array([1.1, NaN, 1.1, 0.1, 0.1, 0.1])).reshape([2, 3, 1])
     const b = sm.tensor(new Float32Array([0.1, 0.1, 1.1, 1.1, 0.1, NaN])).reshape([2, 3, 1])
-    const r = a.lessThan(b)
+    const r = a.lessThanEqual(b)
     expect(isShape(r, [2, 3, 1])).toBe(true)
-    expectArraysClose(r.toFloat32Array(), [0, 0, 0, 1, 0, 0])
+    expectArraysClose(r.toFloat32Array(), [0, 0, 1, 1, 1, 0])
   })
 
   it('4D Tensor', () => {
     let a = sm.tensor(new Float32Array([1, 4, 5, 8])).reshape([2, 2, 1, 1]),
       b = sm.tensor(new Float32Array([2, 3, 6, 7])).reshape([2, 2, 1, 1]),
-      r = sm.lessThan(a, b)
+      r = sm.lessThanEqual(a, b)
     expect(isShape(r, [2, 2, 1, 1])).toBe(true)
     expectArraysClose(r.toFloat32Array(), [1, 0, 1, 0])
 
     a = sm.tensor(new Float32Array([0, 1, 2, 3])).reshape([2, 2, 1, 1])
     b = sm.tensor(new Float32Array([0, 1, 2, 3])).reshape([2, 2, 1, 1])
-    r = sm.lessThan(a, b)
+    r = sm.lessThanEqual(a, b)
     expect(isShape(r, [2, 2, 1, 1])).toBe(true)
-    expectArraysClose(r.toFloat32Array(), [0, 0, 0, 0])
+    expectArraysClose(r.toFloat32Array(), [1, 1, 1, 1])
 
     a = sm.tensor(new Float32Array([1, 1, 1, 1])).reshape([2, 2, 1, 1])
     b = sm.tensor(new Float32Array([2, 2, 2, 2])).reshape([2, 2, 1, 1])
-    r = sm.lessThan(a, b)
+    r = sm.lessThanEqual(a, b)
     expect(isShape(r, [2, 2, 1, 1])).toBe(true)
     expectArraysClose(r.toFloat32Array(), [1, 1, 1, 1])
 
     a = sm.tensor(new Float32Array([1.1, 4.1, 5.1, 8.1])).reshape([2, 2, 1, 1])
     b = sm.tensor(new Float32Array([2.1, 3.1, 6.1, 7.1])).reshape([2, 2, 1, 1])
-    r = sm.lessThan(a, b)
+    r = sm.lessThanEqual(a, b)
     expect(isShape(r, [2, 2, 1, 1])).toBe(true)
     expectArraysClose(r.toFloat32Array(), [1, 0, 1, 0])
 
     a = sm.tensor(new Float32Array([0.1, 1.1, 2.2, 3.3])).reshape([2, 2, 1, 1])
     b = sm.tensor(new Float32Array([0.1, 1.1, 2.2, 3.3])).reshape([2, 2, 1, 1])
-    r = sm.lessThan(a, b)
+    r = sm.lessThanEqual(a, b)
     expect(isShape(r, [2, 2, 1, 1])).toBe(true)
-    expectArraysClose(r.toFloat32Array(), [0, 0, 0, 0])
+    expectArraysClose(r.toFloat32Array(), [1, 1, 1, 1])
 
     a = sm.tensor(new Float32Array([0.1, 0.1, 0.1, 0.1])).reshape([2, 2, 1, 1])
     b = sm.tensor(new Float32Array([1.1, 1.1, 1.1, 1.1])).reshape([2, 2, 1, 1])
-    r = sm.lessThan(a, b)
+    r = sm.lessThanEqual(a, b)
     expect(isShape(r, [2, 2, 1, 1])).toBe(true)
     expectArraysClose(r.toFloat32Array(), [1, 1, 1, 1])
   })
@@ -166,7 +158,7 @@ describe('lessThan', () => {
   it('4D Tensor with NaNs', () => {
     const a = sm.tensor(new Float32Array([1.1, NaN, 0.1, 0.1])).reshape([2, 2, 1, 1])
     const b = sm.tensor(new Float32Array([0.1, 1.1, 1.1, NaN])).reshape([2, 2, 1, 1])
-    const r = a.lessThan(b)
+    const r = a.lessThanEqual(b)
     expect(isShape(r, [2, 2, 1, 1])).toBe(true)
     expectArraysClose(r.toFloat32Array(), [0, 0, 1, 0])
   })

--- a/test/lessThanEqual.test.ts
+++ b/test/lessThanEqual.test.ts
@@ -163,5 +163,5 @@ describe('lessThanEqual', () => {
     expectArraysClose(r.toFloat32Array(), [0, 0, 1, 0])
   })
 
-  /* TODO: unit tests for gradients once supported */
+  /* TODO: unit tests for gradients */
 })

--- a/test/matmul.test.ts
+++ b/test/matmul.test.ts
@@ -1,0 +1,151 @@
+import * as sm from '@shumai/shumai'
+import { it, expect, describe } from 'bun:test'
+import { expectArraysClose, isShape, calcSizeFromShape } from './utils'
+const MATMUL_SHARED_DIM_THRESHOLD = 1000
+
+describe('matmul', () => {
+  it('A x B', () => {
+    const a = sm.tensor(new Float32Array([1, 2, 3, 4, 5, 6])).reshape([2, 3])
+    const b = sm.tensor(new Float32Array([0, 1, -3, 2, 2, 1])).reshape([3, 2])
+    const r = sm.matmul(a, b)
+    expect(isShape(r, [2, 2])).toBe(true)
+    expectArraysClose(r.toFloat32Array(), [0, 8, -3, 20])
+  })
+  it('A (shape=[8,4]) x B (shape=[4,8])', async () => {
+    const a = sm
+      .tensor(
+        new Float32Array([
+          1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 1,
+          2, 3, 4, 5, 6, 7, 8
+        ])
+      )
+      .reshape([8, 4])
+    const b = sm
+      .tensor(
+        new Float32Array([
+          0, 1, -3, 2, 1, -1, 0, 5, 6, 7, 8, 0, -2, -2, 1, 9, 11, 10, 0, 1, -3, 2, 1, -1, 1, 2, 3,
+          4, 5, 6, 7, 8
+        ])
+      )
+      .reshape([4, 8])
+    const r = sm.matmul(a, b)
+    expect(isShape(r, [8, 8])).toBe(true)
+    expectArraysClose(
+      r.toFloat32Array(),
+      [
+        49, 53, 25, 21, 8, 25, 33, 52, 121, 133, 57, 49, 12, 45, 69, 136, 193, 213, 89, 77, 16, 65,
+        105, 220, 265, 293, 121, 105, 20, 85, 141, 304, 337, 373, 153, 133, 24, 105, 177, 388, 409,
+        453, 185, 161, 28, 125, 213, 472, 49, 53, 25, 21, 8, 25, 33, 52, 121, 133, 57, 49, 12, 45,
+        69, 136
+      ]
+    )
+  })
+  it('broadcast w unequal batch dims', () => {
+    const a = sm
+      .tensor(
+        new Float32Array([2, 1, 3, 2, 1, 1, 1, 5, 6, 7, 8, 1, 2, 2, 1, 9, 11, 10, 1, 1, 3, 2, 1, 1])
+      )
+      .reshape([4, 3, 2])
+    const b = sm.tensor(new Float32Array([1, 0.5])).reshape([1, 2, 1])
+    const r = sm.matmul(a, b)
+    expect(isShape(r, [4, 3, 1])).toBe(true)
+    expectArraysClose(r.toFloat32Array(), [2.5, 4, 1.5, 3.5, 9.5, 8.5, 3, 5.5, 16, 1.5, 4, 1.5])
+  })
+
+  /* TODO: FIX - CURRENTLY FAILS (Throws C++ Exception)
+    it('broadcast w unequal ranks', () => {
+      const a = sm
+        .tensor(
+          new Float32Array([2, 1, 3, 2, 1, 1, 1, 5, 6, 7, 8, 1, 2, 2, 1, 9, 11, 10, 1, 1, 3, 2, 1, 1])
+        )
+        .reshape([1, 2, 2, 3, 2])
+      const b = sm.tensor(new Float32Array([1, 0.5])).reshape([2, 1])
+      const r = sm.matmul(a, b)
+      expect(isShape(r, [1, 2, 2, 3, 1])).toBe(true)
+      expectArraysClose(r.toFloat32Array(), [2.5, 4, 1.5, 3.5, 9.5, 8.5, 3, 5.5, 16, 1.5, 4, 1.5])
+    })
+  */
+  it('matmul => mul', () => {
+    const a = sm.tensor(new Float32Array([1, 2, 3, 4])).reshape([2, 2])
+    const b = sm.tensor(new Float32Array([1, 2, 3, 4, 5, 6])).reshape([2, 3])
+    const r1 = sm.matmul(a, b)
+    const c = sm.tensor(new Float32Array([0, 1, 0.5, 0, 0.25, 2])).reshape([2, 3])
+    const r2 = sm.mul(r1, c)
+    expect(isShape(r2, [2, 3])).toBe(true)
+    expectArraysClose(r2.toFloat32Array(), [0, 12, 7.5, 0, 6.5, 66])
+  })
+  it('vector x matrix (w implicit reshape)', () => {
+    const a = sm.tensor(new Float32Array([2, 3]))
+    const b = sm.tensor(new Float32Array([1, 2, 3, 4])).reshape([2, 2])
+    const r = sm.matmul(a, b)
+    expect(isShape(r, [2])).toBe(true)
+    expectArraysClose(r.toFloat32Array(), [11, 16])
+  })
+  it('matrix x vector', () => {
+    const a = sm.tensor(new Float32Array([1, 2, 3, 4])).reshape([2, 2])
+    const b = sm.tensor(new Float32Array([2, 3]))
+    const r = sm.matmul(a, b)
+    expect(isShape(r, [2])).toBe(true)
+    expectArraysClose(r.toFloat32Array(), [8, 18])
+  })
+
+  it('works on batches w matrices as vectors', () => {
+    const BATCH_SIZE = 3
+    const sharedDim = MATMUL_SHARED_DIM_THRESHOLD + 1
+    const values = new Float32Array(BATCH_SIZE * sharedDim)
+    values[10] = 2
+    const a = sm.tensor(values).reshape([BATCH_SIZE, 1, sharedDim])
+    const b = sm.tensor(values).reshape([BATCH_SIZE, sharedDim, 1])
+    const r = sm.matmul(a, b)
+    expect(isShape(r, [BATCH_SIZE, 1, 1])).toBe(true)
+    expectArraysClose(r.toFloat32Array(), [4, 0, 0])
+  })
+  it('works on batches w matrix x vector', () => {
+    const BATCH_SIZE = 3
+    const sharedDim = MATMUL_SHARED_DIM_THRESHOLD + 1
+    const values = new Float32Array(BATCH_SIZE * sharedDim)
+    values[10] = 2
+    const shape1 = [BATCH_SIZE, 2, sharedDim]
+    const a = sm
+      .tensor(new Float32Array(new Array(calcSizeFromShape(shape1)).fill(1)))
+      .reshape(shape1)
+    const b = sm.tensor(values).reshape([BATCH_SIZE, sharedDim, 1])
+    const r = sm.matmul(a, b)
+    expect(isShape(r, [BATCH_SIZE, 2, 1])).toBe(true)
+    expectArraysClose(r.toFloat32Array(), [2, 2, 0, 0, 0, 0])
+  })
+  it('works on batches w vector x matrix', () => {
+    const BATCH_SIZE = 3
+    const sharedDim = MATMUL_SHARED_DIM_THRESHOLD + 1
+    const values = new Float32Array(BATCH_SIZE * sharedDim)
+    values[10] = 2
+    const a = sm.tensor(values).reshape([BATCH_SIZE, 1, sharedDim])
+
+    const bShape = [BATCH_SIZE, sharedDim, 2]
+    const b = sm
+      .tensor(new Float32Array(new Array(calcSizeFromShape(bShape)).fill(1)))
+      .reshape(bShape)
+    const r = sm.matmul(a, b)
+    expect(isShape(r, [BATCH_SIZE, 1, 2])).toBe(true)
+    expectArraysClose(r.toFloat32Array(), [2, 2, 0, 0, 0, 0])
+  })
+  it('matrix x vector propagates NaNs', () => {
+    const a = sm.tensor(new Float32Array([1, 2, 3, 4])).reshape([2, 2])
+    const b = sm.tensor(new Float32Array([2, NaN]))
+    const r = sm.matmul(a, b)
+    expectArraysClose(r.toFloat32Array(), [NaN, NaN])
+  })
+  it('dot product', () => {
+    const a = sm.tensor(new Float32Array([2, 3]))
+    const b = sm.tensor(new Float32Array([2, 1]))
+    const r = sm.matmul(a, b)
+    expectArraysClose(r.toFloat32Array(), [7])
+  })
+  it('dot product propagates NaNs', () => {
+    const a = sm.tensor(new Float32Array([2, NaN]))
+    const b = sm.tensor(new Float32Array([2, 1]))
+    const r = sm.matmul(a, b)
+    expectArraysClose(r.toFloat32Array(), [NaN])
+  })
+  /* TODO: unit tests for gradients */
+})

--- a/test/mean.test.ts
+++ b/test/mean.test.ts
@@ -73,5 +73,5 @@ describe('mean', () => {
     expectArraysClose(mean.toFloat32Array(), [7 / 6])
   })
 
-  /* TODO: unit tests for gradients once supported */
+  /* TODO: unit tests for gradients */
 })

--- a/test/negative.test.ts
+++ b/test/negative.test.ts
@@ -21,5 +21,5 @@ describe('negative', () => {
     expectArraysClose(r.toFloat32Array(), [-1, 3, NaN, -7, 10234])
   })
 
-  /* TODO: unit tests for gradients once supported */
+  /* TODO: unit tests for gradients */
 })

--- a/test/sigmoid.test.ts
+++ b/test/sigmoid.test.ts
@@ -35,5 +35,5 @@ describe('sigmoid', () => {
     expectArraysClose(r.toFloat32Array(), [1 / (1 + Math.exp(-3)), NaN])
   })
 
-  /* TODO: unit tests for gradients once supported */
+  /* TODO: unit tests for gradients */
 })

--- a/test/sign.test.ts
+++ b/test/sign.test.ts
@@ -17,5 +17,5 @@ describe('sign', () => {
     expectArraysClose(r.toFloat32Array(), [1, 0, -1])
   })
 
-  /* TODO: unit tests for gradients once supported */
+  /* TODO: unit tests for gradients */
 })

--- a/test/sin.test.ts
+++ b/test/sin.test.ts
@@ -19,5 +19,5 @@ describe('sin', () => {
     expectArraysClose(r.toFloat32Array(), [Math.sin(4), NaN, Math.sin(0)])
   })
 
-  /* TODO: unit tests for gradients once supported */
+  /* TODO: unit tests for gradients */
 })

--- a/test/sum.test.ts
+++ b/test/sum.test.ts
@@ -72,5 +72,5 @@ describe('sum', () => {
     expectArraysClose(sum.toFloat32Array(), [1, 2, 3, 4])
   })
 
-  /* TODO: unit tests for gradients once supported */
+  /* TODO: unit tests for gradients */
 })

--- a/test/tanh.test.ts
+++ b/test/tanh.test.ts
@@ -1,0 +1,24 @@
+import { it, describe } from 'bun:test'
+import * as sm from '@shumai/shumai'
+import { expectArraysClose } from './utils'
+
+describe('tanh', () => {
+  it('basic', () => {
+    const values = [1, -3, 2, 7, -4]
+    const a = sm.tensor(new Float32Array([1, -3, 2, 7, -4]))
+    const r = sm.tanh(a)
+    expectArraysClose(
+      r.toFloat32Array(),
+      values.map((v) => Math.tanh(v))
+    )
+  })
+  it('propagates NaNs', () => {
+    const values = [4, NaN, 0]
+    const a = sm.tensor(new Float32Array(values))
+    const r = sm.tanh(a)
+    expectArraysClose(
+      r.toFloat32Array(),
+      values.map((v) => Math.tanh(v))
+    )
+  })
+})

--- a/test/tile.test.ts
+++ b/test/tile.test.ts
@@ -72,5 +72,5 @@ describe('tile', () => {
     expectArraysClose(t2.toFloat32Array(), [1, 2, NaN, 1, 2, NaN])
   })
 
-  /* TODO: unit tests for gradients once supported */
+  /* TODO: unit tests for gradients */
 })

--- a/test/transpose.test.ts
+++ b/test/transpose.test.ts
@@ -171,5 +171,5 @@ describe('transpose', () => {
     })
   */
 
-  /* TODO: unit tests for gradients once supported */
+  /* TODO: unit tests for gradients */
 })

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -57,13 +57,18 @@ export const isClose = (actual: number | bigint, expected: number | bigint, erro
 }
 
 /* validates that actual && expected array are close (all values w/i given tolerance) */
-const isCloseArr = (actual: util.ArrayLike, expected: util.ArrayLike, error: number) => {
-  const expLength = expected.length
-  if (actual.length !== expLength) return false
+const isCloseArr = (actual: util.ArrayLike, expected: util.ArrayLike | number, error: number) => {
+  if (typeof expected === 'number') expected = [expected]
+  const expLength = expected.length,
+    actualLength = actual.length
+  if (actualLength !== expLength) {
+    logShape([actualLength], [expLength])
+    return false
+  }
 
   for (let i = 0; i < expLength; i++) {
     if (!isClose(actual[i], expected[i], error)) {
-      for (let j = 0; j < actual.length; j++) {
+      for (let j = 0; j < actualLength; j++) {
         console.log(
           `expected[${j}]:`,
           expected[j].toString(),
@@ -80,6 +85,6 @@ const isCloseArr = (actual: util.ArrayLike, expected: util.ArrayLike, error: num
 
 export const expectArraysClose = (
   actual: util.ArrayLike,
-  expected: util.ArrayLike,
+  expected: util.ArrayLike | number,
   error = 0.001
 ) => expect(isCloseArr(actual, expected, error)).toBe(true)

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -5,14 +5,23 @@ import { util } from '@shumai/shumai'
 export const calcSizeFromShape = (arr: number[]) =>
   arr.reduce((acc, val, i) => (i === 0 ? val : acc * val), 0)
 
+const logShape = (actual_shape: number[], expected_shape: number[]) =>
+  console.log('actual_shape: ', actual_shape, '  ** vs **  ', 'expected_shape: ', expected_shape)
+
 /**
  * exported helper functions to make up for bun's wiptest
  * lacking some features
  */
 export const isShape = (t: Tensor, expectedShape: number[]) => {
-  if (t.shape.length !== expectedShape.length) return false
+  if (t.shape.length !== expectedShape.length) {
+    logShape(t.shape, expectedShape)
+    return false
+  }
   for (let i = 0; i < t.shape.length; i++) {
-    if (t.shape[i] !== expectedShape[i]) return false
+    if (t.shape[i] !== expectedShape[i]) {
+      logShape(t.shape, expectedShape)
+      return false
+    }
   }
   return true
 }
@@ -20,7 +29,9 @@ export const isShape = (t: Tensor, expectedShape: number[]) => {
 export const areSameShape = (t1: Tensor, t2: Tensor) => {
   const count = t1.shape.length >= t2.shape.length ? t1.shape.length : t2.shape.length
   for (let i = 0; i <= count; i++) {
-    if (t1.shape[i] !== t2.shape[i]) return false
+    if (t1.shape[i] !== t2.shape[i]) {
+      return false
+    }
   }
   return true
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,7 @@
       "@shumai/shumai": ["./shumai/index.ts"],
     }
   },
-  "exclude": ["examples/**/*", "build/**/*", "docs/assets/**/*"],
+  "exclude": ["examples/**/*.js", "build/**/*", "docs/assets/**/*"],
   "typedocOptions": {
     "entryPoints": ["shumai/index.ts"],
     "out": "docs",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,7 @@
       "@shumai/shumai": ["./shumai/index.ts"],
     }
   },
-  "exclude": ["examples/**/*.js", "build/**/*", "docs/assets/**/*"],
+  "exclude": ["examples/**/*", "build/**/*", "docs/assets/**/*"],
   "typedocOptions": {
     "entryPoints": ["shumai/index.ts"],
     "out": "docs",


### PR DESCRIPTION
Now that we've fixed the bug in `buffer`, wanted to get the unit tests for greaterThan, greaterThanEqual, & lessThanEqual added.

### Supported Operations Tests
- [x] abs (TODO: addtl tests in `abs.test.ts` after basic op coverage)
- [x] absolute (implicit, since the same as `abs`)
- [x] add
- [x] all
- [ ] amax
- [ ] amin
- [ ] any
- [ ] arange
- [x] argmax
- [x] argmin
- [ ] backward
- [ ] bitwiseAnd
- [ ] bitwiseOr
- [ ] bitwiseXor
- [ ] bytesUsed
- [x] ceil
- [ ] clip
- [x] cos
- [ ] countNonzero
- [ ] cumsum
- [x] div
- [ ] eq
- [x] erf
- [x] exp
- [ ] flip (WIP; failing)
- [x] floor
- [ ] full
- [x] greaterThan
- [x] greaterThanEqual
- [ ] identity
- [ ] iota
- [x] isinf
- [x] isnan
- [ ] lShift
- [x] lessThan
- [x] lessThanEqual
- [x] log
- [ ] log1p
- [ ] logicalAnd
- [ ] logicalNot
- [ ] logicalOr
- [x] matmul
- [x] maximum
- [x] mean
- [ ] median
- [x] minimum
- [ ] mod
- [x] mul
- [x] negative
- [ ] neq
- [ ] nonzero
- [x] norm
- [ ] power
- [ ] rShift
- [ ] rand
- [ ] randn
- [x] reshape
- [ ] rint
- [ ] roll
- [x] scalar
- [x] sigmoid
- [x] sign
- [x] sin
- [ ] sort
- [ ] sqrt
- [ ] std
- [x] sub
- [x] sum
- [x] tanh
- [x] tensor
- [x] tile
- [x] transpose
- [ ] tril
- [ ] triu
- [ ] where

### Tensor Class Methods & Properties Tests
- [ ] asContiguousTensor
- [x] elements (used in tests)
- [ ] ndim
- [ ] ptr (need test for this?)
- [x] shape (used in tests)
- [ ] shape64
- [x] copy
- [ ] deepCopy
- [ ] detach
- [x] index
- [x] indexedAssign
- [ ] requireGrad
- [x] toFloat32
- [x] toFloat32Array
- [ ] toString
- [ ] update
- [ ] valueOf
- [ ] var