### PR TITLE
Added additional unit tests for Ops

### DIFF
--- a/test/any.test.ts
+++ b/test/any.test.ts
@@ -1,0 +1,56 @@
+import { it, describe, expect } from 'bun:test'
+import * as sm from '@shumai/shumai'
+import { expectArraysClose, isShape } from './utils'
+
+describe('any', () => {
+  it('1D Tensor', () => {
+    let a = sm.tensor(new Float32Array([0, 0, 0]))
+    expectArraysClose(sm.any(a).toFloat32Array(), [0])
+
+    a = sm.tensor(new Float32Array([1, 0, 1]))
+    expectArraysClose(sm.any(a).toFloat32Array(), [1])
+
+    a = sm.tensor(new Float32Array([1, 1, 1]))
+    expectArraysClose(sm.any(a).toFloat32Array(), [1])
+  })
+  it('ignores NaNs', () => {
+    const a = sm.tensor(new Float32Array([1, NaN, 0]))
+    expectArraysClose(sm.any(a).toFloat32Array(), [1])
+  })
+  it('2D Tensor', () => {
+    const a = sm.tensor(new Float32Array([1, 1, 0, 0])).reshape([2, 2])
+    expectArraysClose(sm.any(a).toFloat32Array(), [1])
+  })
+  it('2D Tensor, axis=[0, 1]', () => {
+    const a = sm.tensor(new Float32Array([1, 1, 0, 0, 1, 0])).reshape([2, 3])
+    expectArraysClose(sm.any(a, [0, 1]).toFloat32Array(), [1])
+  })
+  it('2D Tensor, axis=[0]/axis=[1]', () => {
+    const a = sm.tensor(new Float32Array([1, 1, 0, 0])).reshape([2, 2])
+    let r = sm.any(a, [0])
+    expect(isShape(r, [2])).toBe(true)
+    expectArraysClose(r.toFloat32Array(), [1, 1])
+
+    r = sm.any(a, [1])
+    expect(isShape(r, [2])).toBe(true)
+    expectArraysClose(r.toFloat32Array(), [1, 0])
+  })
+  it('2D Tensor, axis=[0] & keep_dims=true', () => {
+    const a = sm.tensor(new Float32Array([1, 1, 0, 0, 1, 0])).reshape([2, 3])
+    const r = a.any([0], true)
+    expect(isShape(r, [1, 3])).toBe(true)
+    expectArraysClose(r.toFloat32Array(), [1, 1, 0])
+  })
+  it('2D Tensor, axis=[1]', () => {
+    const a = sm.tensor(new Float32Array([1, 1, 0, 0, 1, 0])).reshape([2, 3])
+    expectArraysClose(a.any([1]).toFloat32Array(), [1, 1])
+  })
+  it('2D Tensor, axis=[-1]', () => {
+    const a = sm.tensor(new Float32Array([1, 1, 0, 0, 1, 0])).reshape([2, 3])
+    expectArraysClose(a.any([-1]).toFloat32Array(), [1, 1])
+  })
+  it('2D Tensor, axis=[-1]', () => {
+    const a = sm.tensor(new Float32Array([1, 1, 0, 0, 1, 0])).reshape([2, 3])
+    expectArraysClose(a.any([-1]).toFloat32Array(), [1, 1])
+  })
+})

--- a/test/cumsum.test.ts
+++ b/test/cumsum.test.ts
@@ -16,9 +16,10 @@ describe('cumsum', () => {
     expect(isShape(r, [2, 2]))
     expectArraysClose(r.toFloat32Array(), [1, 3, 3, 7])
   })
+  /* TODO: FIX - CURRENTLY FAILS */
   it('2D Tensor, axis=0', () => {
     const a = sm.tensor(new Float32Array([1, 2, 3, 4])).reshape([2, 2])
-    const r = a.cumsum(1)
+    const r = a.cumsum(0)
     expect(isShape(r, [2, 2]))
     expectArraysClose(r.toFloat32Array(), [1, 2, 4, 6])
   })

--- a/test/cumsum.test.ts
+++ b/test/cumsum.test.ts
@@ -1,0 +1,32 @@
+import { it, describe, expect } from 'bun:test'
+import * as sm from '@shumai/shumai'
+import { expectArraysClose, isShape } from './utils'
+
+describe('cumsum', () => {
+  it('1D Tensor', () => {
+    const a = sm.tensor(new Float32Array([1, 2, 3, 4]))
+    const r = a.cumsum(0)
+    expect(isShape(r, [4])).toBe(true)
+    expectArraysClose(r.toFloat32Array(), [1, 3, 6, 10])
+  })
+  /* TODO: FIX - CURRENTLY FAILS */
+  it('2D Tensor, axis=1', () => {
+    const a = sm.tensor(new Float32Array([1, 2, 3, 4])).reshape([2, 2])
+    const r = a.cumsum(1)
+    expect(isShape(r, [2, 2]))
+    expectArraysClose(r.toFloat32Array(), [1, 3, 3, 7])
+  })
+  it('2D Tensor, axis=0', () => {
+    const a = sm.tensor(new Float32Array([1, 2, 3, 4])).reshape([2, 2])
+    const r = a.cumsum(1)
+    expect(isShape(r, [2, 2]))
+    expectArraysClose(r.toFloat32Array(), [1, 2, 4, 6])
+  })
+  it('3D Tensor, axis=0', () => {
+    const a = sm.tensor(new Float32Array([0, 1, 2, 3, 4, 5, 6, 7])).reshape([2, 2, 2])
+    const r = a.cumsum(0)
+    expect(isShape(r, [2, 2, 2]))
+    expectArraysClose(r.toFloat32Array(), [0, 1, 2, 5, 4, 9, 6, 13])
+  })
+  /* TODO: unit tests for gradients */
+})

--- a/test/flip.test.ts
+++ b/test/flip.test.ts
@@ -6,12 +6,12 @@ describe('flip', () => {
   /* TODO: FIX - CURRENTLY FAILS */
   it('basic (1D Tensor)', () => {
     const t = sm.tensor(new Float32Array([0, 1, 2, 3]))
-    const r = sm.flip(t, 1)
+    const r = sm.flip(t, 0)
     expect(isShape(r, [4])).toBe(true)
     expectArraysClose(r.toFloat32Array(), [3, 2, 1, 0])
 
     const t2 = sm.tensor(new Float32Array([12345678, 2, 1, 0]))
-    const r2 = sm.flip(t2, 1)
+    const r2 = sm.flip(t2, 0)
     expect(isShape(r2, [4])).toBe(true)
     expectArraysClose(r2.toFloat32Array(), [0, 1, 2, 12345678])
   })

--- a/test/log1p.test.ts
+++ b/test/log1p.test.ts
@@ -1,6 +1,6 @@
-import { it, describe, expect } from 'bun:test'
+import { it, describe } from 'bun:test'
 import * as sm from '@shumai/shumai'
-import { expectArraysClose, isShape } from './utils'
+import { expectArraysClose } from './utils'
 
 describe('log1p', () => {
   it('basic', () => {
@@ -16,7 +16,6 @@ describe('log1p', () => {
     const values = [1, NaN]
     const a = sm.tensor(new Float32Array(values))
     const r = a.log1p()
-    expect(isShape(r, [2, 2]))
     expectArraysClose(
       r.toFloat32Array(),
       values.map((v) => Math.log1p(v))

--- a/test/log1p.test.ts
+++ b/test/log1p.test.ts
@@ -1,0 +1,26 @@
+import { it, describe, expect } from 'bun:test'
+import * as sm from '@shumai/shumai'
+import { expectArraysClose, isShape } from './utils'
+
+describe('log1p', () => {
+  it('basic', () => {
+    const values = [1, 2]
+    const a = sm.tensor(new Float32Array(values))
+    const r = sm.log1p(a)
+    expectArraysClose(
+      r.toFloat32Array(),
+      values.map((v) => Math.log1p(v))
+    )
+  })
+  it('propagates NaNs', () => {
+    const values = [1, NaN]
+    const a = sm.tensor(new Float32Array(values))
+    const r = a.log1p()
+    expect(isShape(r, [2, 2]))
+    expectArraysClose(
+      r.toFloat32Array(),
+      values.map((v) => Math.log1p(v))
+    )
+  })
+  /* TODO: unit tests for gradients */
+})

--- a/test/logicalAnd.test.ts
+++ b/test/logicalAnd.test.ts
@@ -1,0 +1,61 @@
+import { it, describe } from 'bun:test'
+import * as sm from '@shumai/shumai'
+import { expectArraysClose } from './utils'
+
+describe('logicalAnd', () => {
+  it('1D Tensor', () => {
+    let a = sm.tensor(new Float32Array([1, 0, 0]))
+    let b = sm.tensor(new Float32Array([0, 1, 0]))
+    expectArraysClose(sm.logicalAnd(a, b).toFloat32Array(), [0, 0, 0])
+
+    a = sm.tensor(new Float32Array([0, 0, 0]))
+    b = sm.tensor(new Float32Array([0, 0, 0]))
+    expectArraysClose(sm.logicalAnd(a, b).toFloat32Array(), [0, 0, 0])
+
+    a = sm.tensor(new Float32Array([1, 1]))
+    b = sm.tensor(new Float32Array([1, 1]))
+    expectArraysClose(sm.logicalAnd(a, b).toFloat32Array(), [1, 1])
+  })
+  it('2D Tensor', () => {
+    let a = sm.tensor(new Float32Array([1, 0, 1, 0, 0, 0])).reshape([2, 3])
+    let b = sm.tensor(new Float32Array([0, 0, 0, 0, 1, 0])).reshape([2, 3])
+    expectArraysClose(sm.logicalAnd(a, b).toFloat32Array(), [0, 0, 0, 0, 0, 0])
+
+    a = sm.tensor(new Float32Array([0, 0, 0, 1, 1, 1]))
+    b = sm.tensor(new Float32Array([0, 0, 0, 1, 1, 1]))
+    expectArraysClose(sm.logicalAnd(a, b).toFloat32Array(), [0, 0, 0, 1, 1, 1])
+  })
+  it('broadcasts 2D Tensor shapes', () => {
+    const a = sm.tensor(new Float32Array([1, 0])).reshape([2, 1])
+    const b = sm.tensor(new Float32Array([0, 1, 0, 0, 1, 0])).reshape([2, 3])
+    expectArraysClose(sm.logicalAnd(a, b).toFloat32Array(), [0, 1, 0, 0, 0, 0])
+  })
+  it('3D Tensor', () => {
+    let a = sm.tensor(new Float32Array([1, 0, 1, 0, 0, 1])).reshape([2, 3, 1])
+    let b = sm.tensor(new Float32Array([0, 0, 1, 1, 0, 0])).reshape([2, 3, 1])
+    expectArraysClose(sm.logicalAnd(a, b).toFloat32Array(), [0, 0, 1, 0, 0, 0])
+
+    a = sm.tensor(new Float32Array([0, 0, 0, 1, 1, 1])).reshape([2, 3, 1])
+    b = sm.tensor(new Float32Array([0, 0, 0, 1, 1, 1])).reshape([2, 3, 1])
+    expectArraysClose(sm.logicalAnd(a, b).toFloat32Array(), [0, 0, 0, 1, 1, 1])
+  })
+  it('broadcasts 3D Tensor shapes', () => {
+    const a = sm.tensor(new Float32Array([1, 0, 0, 0, 1, 1, 0, 0, 0, 1, 0, 0])).reshape([2, 3, 2])
+    const b = sm.tensor(new Float32Array([0, 0, 1, 1, 0, 0])).reshape([2, 3, 1])
+    expectArraysClose(sm.logicalAnd(a, b).toFloat32Array(), [0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0])
+  })
+  it('4D Tensor', () => {
+    let a = sm.tensor(new Float32Array([1, 0, 1, 0])).reshape([2, 2, 1, 1])
+    let b = sm.tensor(new Float32Array([0, 1, 1, 0])).reshape([2, 2, 1, 1])
+    expectArraysClose(sm.logicalAnd(a, b).toFloat32Array(), [0, 0, 1, 0])
+
+    a = sm.tensor(new Float32Array([0, 0, 0, 0])).reshape([2, 2, 1, 1])
+    b = sm.tensor(new Float32Array([0, 0, 0, 0])).reshape([2, 2, 1, 1])
+    expectArraysClose(sm.logicalAnd(a, b).toFloat32Array(), [0, 0, 0, 0])
+
+    a = sm.tensor(new Float32Array([1, 1, 1, 1])).reshape([2, 2, 1, 1])
+    b = sm.tensor(new Float32Array([1, 1, 1, 1])).reshape([2, 2, 1, 1])
+    expectArraysClose(sm.logicalAnd(a, b).toFloat32Array(), [1, 1, 1, 1])
+  })
+  /* TODO: unit tests for gradients */
+})

--- a/test/logicalNot.test.ts
+++ b/test/logicalNot.test.ts
@@ -1,0 +1,57 @@
+import { it, describe } from 'bun:test'
+import * as sm from '@shumai/shumai'
+import { expectArraysClose } from './utils'
+
+describe('logicalNot', () => {
+  it('1D Tensor', () => {
+    let a = sm.tensor(new Float32Array([1, 0, 0]))
+    expectArraysClose(sm.logicalNot(a).toFloat32Array(), [0, 1, 1])
+
+    a = sm.tensor(new Float32Array([0, 0, 0]))
+    expectArraysClose(sm.logicalNot(a).toFloat32Array(), [1, 1, 1])
+
+    a = sm.tensor(new Float32Array([1, 1]))
+    expectArraysClose(sm.logicalNot(a).toFloat32Array(), [0, 0])
+  })
+  it('1D Tensor, chaining', () => {
+    let a = sm.tensor(new Float32Array([1, 0, 0]))
+    expectArraysClose(a.logicalNot().toFloat32Array(), [0, 1, 1])
+
+    a = sm.tensor(new Float32Array([0, 0, 0]))
+    expectArraysClose(a.logicalNot().toFloat32Array(), [1, 1, 1])
+
+    a = sm.tensor(new Float32Array([1, 1]))
+    expectArraysClose(a.logicalNot().toFloat32Array(), [0, 0])
+  })
+  it('2D Tensor', () => {
+    let a = sm.tensor(new Float32Array([1, 0, 1, 0, 0, 0])).reshape([2, 3])
+    expectArraysClose(sm.logicalNot(a).toFloat32Array(), [0, 1, 0, 1, 1, 1])
+
+    a = sm.tensor(new Float32Array([0, 0, 0, 1, 1, 1])).reshape([2, 3])
+    expectArraysClose(sm.logicalNot(a).toFloat32Array(), [1, 1, 1, 0, 0, 0])
+  })
+  it('3D Tensor', () => {
+    let a = sm.tensor(new Float32Array([1, 0, 1, 0, 0, 0])).reshape([2, 3, 1])
+    expectArraysClose(sm.logicalNot(a).toFloat32Array(), [0, 1, 0, 1, 1, 1])
+
+    a = sm.tensor(new Float32Array([0, 0, 0, 1, 1, 1])).reshape([2, 3, 1])
+    expectArraysClose(sm.logicalNot(a).toFloat32Array(), [1, 1, 1, 0, 0, 0])
+  })
+  it('4D Tensor', () => {
+    let a = sm.tensor(new Float32Array([1, 0, 1, 0])).reshape([2, 2, 1, 1])
+    expectArraysClose(sm.logicalNot(a).toFloat32Array(), [0, 1, 0, 1])
+
+    a = sm.tensor(new Float32Array([0, 0, 0, 0])).reshape([2, 2, 1, 1])
+    expectArraysClose(sm.logicalNot(a).toFloat32Array(), [1, 1, 1, 1])
+
+    a = sm.tensor(new Float32Array([1, 1, 1, 1])).reshape([2, 2, 1, 1])
+    expectArraysClose(sm.logicalNot(a).toFloat32Array(), [0, 0, 0, 0])
+  })
+  /* TODO: FIX - CURRENTLY FAILS (Throws C++ Exception)
+    it('6D Tensor', () => {
+      const a = sm.tensor(new Float32Array([1, 0, 1, 0])).reshape([2, 2, 1, 1, 1, 1])
+      expectArraysClose(sm.logicalNot(a).toFloat32Array(), [0, 1, 0, 1])
+    })
+  */
+  /* TODO: unit tests for gradients */
+})

--- a/test/logicalOr.test.ts
+++ b/test/logicalOr.test.ts
@@ -1,0 +1,66 @@
+import { it, describe } from 'bun:test'
+import * as sm from '@shumai/shumai'
+import { expectArraysClose } from './utils'
+
+describe('logicalOr', () => {
+  it('1D Tensor', () => {
+    let a = sm.tensor(new Float32Array([1, 0, 0]))
+    let b = sm.tensor(new Float32Array([0, 1, 0]))
+    expectArraysClose(sm.logicalOr(a, b).toFloat32Array(), [1, 1, 0])
+
+    a = sm.tensor(new Float32Array([0, 0, 0]))
+    b = sm.tensor(new Float32Array([0, 0, 0]))
+    expectArraysClose(sm.logicalOr(a, b).toFloat32Array(), [0, 0, 0])
+
+    a = sm.tensor(new Float32Array([1, 1]))
+    b = sm.tensor(new Float32Array([1, 1]))
+    expectArraysClose(sm.logicalOr(a, b).toFloat32Array(), [1, 1])
+  })
+  it('2D Tensor', () => {
+    let a = sm.tensor(new Float32Array([1, 0, 1, 0, 0, 0])).reshape([2, 3])
+    let b = sm.tensor(new Float32Array([0, 0, 0, 0, 1, 0])).reshape([2, 3])
+    expectArraysClose(sm.logicalOr(a, b).toFloat32Array(), [1, 0, 1, 0, 1, 0])
+
+    a = sm.tensor(new Float32Array([0, 0, 0, 1, 1, 1])).reshape([2, 3])
+    b = sm.tensor(new Float32Array([0, 0, 0, 1, 1, 1])).reshape([2, 3])
+    expectArraysClose(sm.logicalOr(a, b).toFloat32Array(), [0, 0, 0, 1, 1, 1])
+  })
+  it('broadcast 2D Tensor shapes', () => {
+    const a = sm.tensor(new Float32Array([1, 0])).reshape([2, 1])
+    const b = sm.tensor(new Float32Array([0, 0, 0, 0, 1, 0])).reshape([2, 3])
+    expectArraysClose(sm.logicalOr(a, b).toFloat32Array(), [1, 1, 1, 0, 1, 0])
+  })
+  it('3D Tensor', () => {
+    let a = sm.tensor(new Float32Array([1, 0, 1, 0, 0, 0])).reshape([2, 3, 1])
+    let b = sm.tensor(new Float32Array([0, 0, 1, 1, 0, 0])).reshape([2, 3, 1])
+    expectArraysClose(sm.logicalOr(a, b).toFloat32Array(), [1, 0, 1, 1, 0, 0])
+
+    a = sm.tensor(new Float32Array([0, 0, 0, 1, 1, 1])).reshape([2, 3, 1])
+    b = sm.tensor(new Float32Array([0, 0, 0, 1, 1, 1])).reshape([2, 3, 1])
+    expectArraysClose(sm.logicalOr(a, b).toFloat32Array(), [0, 0, 0, 1, 1, 1])
+  })
+  it('broadcast 3D Tensor shapes', () => {
+    const a = sm.tensor(new Float32Array([1, 0, 0, 0, 1, 1, 0, 0, 0, 1, 0, 0])).reshape([2, 3, 2])
+    const b = sm.tensor(new Float32Array([0, 0, 1, 1, 0, 0])).reshape([2, 3, 1])
+    expectArraysClose(sm.logicalOr(a, b).toFloat32Array(), [1, 0, 0, 0, 1, 1, 1, 1, 0, 1, 0, 0])
+  })
+  it('4D Tensor', () => {
+    let a = sm.tensor(new Float32Array([1, 0, 1, 0])).reshape([2, 2, 1, 1])
+    let b = sm.tensor(new Float32Array([0, 1, 0, 0])).reshape([2, 2, 1, 1])
+    expectArraysClose(sm.logicalOr(a, b).toFloat32Array(), [1, 1, 1, 0])
+
+    a = sm.tensor(new Float32Array([0, 0, 0, 0])).reshape([2, 2, 1, 1])
+    b = sm.tensor(new Float32Array([0, 0, 0, 0])).reshape([2, 2, 1, 1])
+    expectArraysClose(sm.logicalOr(a, b).toFloat32Array(), [0, 0, 0, 0])
+
+    a = sm.tensor(new Float32Array([1, 1, 1, 1])).reshape([2, 2, 1, 1])
+    b = sm.tensor(new Float32Array([1, 1, 1, 1])).reshape([2, 2, 1, 1])
+    expectArraysClose(sm.logicalOr(a, b).toFloat32Array(), [1, 1, 1, 1])
+  })
+  it('broadcast 4D Tensor shapes', () => {
+    const a = sm.tensor(new Float32Array([1, 0, 1, 0])).reshape([2, 2, 1, 1])
+    const b = sm.tensor(new Float32Array([1, 0, 0, 0, 0, 0, 1, 1])).reshape([2, 2, 1, 2])
+    expectArraysClose(sm.logicalOr(a, b).toFloat32Array(), [1, 1, 0, 0, 1, 1, 1, 1])
+  })
+  /* TODO: unit tests for gradients */
+})

--- a/test/mean.test.ts
+++ b/test/mean.test.ts
@@ -32,7 +32,7 @@ describe('mean', () => {
   /* TODO: FIX - CURRENTLY FAILS */
   it('works for 2D Tensor; keep_dims=true', () => {
     const t = sm.tensor(new Float32Array([1, 2, 3, 0, 0, 1])).reshape([3, 2])
-    const mean = sm.mean(t, [], true)
+    const mean = t.mean([], true)
     expect(isShape(mean, [1, 1])).toBe(true)
     expect(isClose(mean.toFloat32(), 7 / 6)).toBe(true)
   })

--- a/test/sqrt.test.ts
+++ b/test/sqrt.test.ts
@@ -1,0 +1,23 @@
+import { it, describe } from 'bun:test'
+import * as sm from '@shumai/shumai'
+import { expectArraysClose } from './utils'
+
+describe('sqrt', () => {
+  it('basic', () => {
+    const values = [2, 4]
+    const a = sm.tensor(new Float32Array(values))
+    expectArraysClose(
+      sm.sqrt(a).toFloat32Array(),
+      values.map((v) => Math.sqrt(v))
+    )
+  })
+  it('propagates NaNs', () => {
+    const values = [1, NaN]
+    const a = sm.tensor(new Float32Array(values))
+    expectArraysClose(
+      sm.sqrt(a).toFloat32Array(),
+      values.map((v) => Math.sqrt(v))
+    )
+  })
+  /* TODO: unit tests for gradients */
+})

--- a/test/transpose.test.ts
+++ b/test/transpose.test.ts
@@ -9,36 +9,30 @@ describe('transpose', () => {
     expect(areSameShape(t, r)).toBe(true)
     expectArraysClose(r.toFloat32Array(), t.toFloat32Array())
   })
-
-  /* TODO: FIX - CURRENTLY FAILS */
   it('2D Tensor', () => {
     const t = sm.tensor(new Float32Array([1, 11, 2, 22, 3, 33, 4, 44])).reshape([2, 4])
-    t.transpose([1, 0])
-    expect(isShape(t, [2, 4])).toBe(true)
-    expectArraysClose(t.toFloat32Array(), [1, 3, 11, 33, 2, 4, 22, 44])
+    const t2 = t.transpose([1, 0])
+    expect(isShape(t2, [4, 2])).toBe(true)
+    expectArraysClose(t2.toFloat32Array(), [1, 3, 11, 33, 2, 4, 22, 44])
   })
-
   it('2D Tensor; shape has ones', () => {
     const t = sm.tensor(new Float32Array([1, 2, 3, 4])).reshape([1, 4])
     const t2 = sm.transpose(t, [1, 0])
     expect(isShape(t2, [4, 1])).toBe(true)
     expectArraysClose(t2.toFloat32Array(), [1, 2, 3, 4])
   })
-
   it('3D Tensor [r, c, d] => [d, r, c]', () => {
     const t = sm.tensor(new Float32Array([1, 11, 2, 22, 3, 33, 4, 44])).reshape([2, 2, 2])
     const t2 = sm.transpose(t, [2, 0, 1])
     expect(isShape(t2, [2, 2, 2])).toBe(true)
     expectArraysClose(t2.toFloat32Array(), [1, 2, 3, 4, 11, 22, 33, 44])
   })
-
   it('3D Tensor [r, c, d] => [d, c, r]', () => {
     const t = sm.tensor(new Float32Array([1, 11, 2, 22, 3, 33, 4, 44])).reshape([2, 2, 2])
     const t2 = sm.transpose(t, [2, 1, 0])
     expect(isShape(t2, [2, 2, 2])).toBe(true)
     expectArraysClose(t2.toFloat32Array(), [1, 3, 2, 4, 11, 33, 22, 44])
   })
-
   it('3D Tensor [r, c, d] => [d, r, c], shape has ones', () => {
     const perm = [2, 0, 1]
     const t = sm.tensor(new Float32Array([1, 2, 3, 4])).reshape([2, 1, 2])
@@ -56,7 +50,6 @@ describe('transpose', () => {
     expect(isShape(tt3, [2, 1, 2])).toBe(true)
     expectArraysClose(tt3.toFloat32Array(), [1, 3, 2, 4])
   })
-
   it('3D Tensor [r, c, d] => [r, d, c]', () => {
     const perm = [0, 2, 1]
     const t = sm.tensor(new Float32Array([1, 2, 3, 4, 5, 6, 7, 8])).reshape([2, 2, 2])
@@ -64,7 +57,6 @@ describe('transpose', () => {
     expect(isShape(tt, [2, 2, 2])).toBe(true)
     expectArraysClose(tt.toFloat32Array(), [1, 3, 2, 4, 5, 7, 6, 8])
   })
-
   /* TODO: FIX - CURRENTLY FAILS (Throws C++ Exception)
     it('5D Tensor [r, c, d, e, f] => [r, c, d, f, e]', () => {
       const t = sm
@@ -81,7 +73,6 @@ describe('transpose', () => {
       )
     })
   */
-
   it('4D Tensor [r, c, d, e] => [c, r, d, e]', () => {
     const t = sm
       .tensor(new Float32Array(new Array(16).fill(0).map((x, i) => i + 1)))
@@ -90,7 +81,6 @@ describe('transpose', () => {
     expect(isShape(t2, [2, 2, 2, 2])).toBe(true)
     expectArraysClose(t2.toFloat32Array(), [1, 2, 3, 4, 9, 10, 11, 12, 5, 6, 7, 8, 13, 14, 15, 16])
   })
-
   it('4D Tensor [r, c, d, e] => [c, r, e, d]', () => {
     const t = sm
       .tensor(new Float32Array(new Array(16).fill(0).map((x, i) => i + 1)))
@@ -99,7 +89,6 @@ describe('transpose', () => {
     expect(isShape(t2, [2, 2, 2, 2])).toBe(true)
     expectArraysClose(t2.toFloat32Array(), [1, 3, 2, 4, 9, 11, 10, 12, 5, 7, 6, 8, 13, 15, 14, 16])
   })
-
   it('4D Tensor [r, c, d, e] => [e, r, c, d]', () => {
     const t = sm
       .tensor(new Float32Array(new Array(16).fill(0).map((x, i) => i + 1)))
@@ -108,7 +97,6 @@ describe('transpose', () => {
     expect(isShape(t2, [2, 2, 2, 2])).toBe(true)
     expectArraysClose(t2.toFloat32Array(), [1, 3, 5, 7, 9, 11, 13, 15, 2, 4, 6, 8, 10, 12, 14, 16])
   })
-
   it('4D Tensor [r, c, d, e] => [d, c, e, r]', () => {
     const t = sm
       .tensor(new Float32Array(new Array(16).fill(0).map((x, i) => i + 1)))
@@ -117,7 +105,6 @@ describe('transpose', () => {
     expect(isShape(t2, [2, 2, 2, 2])).toBe(true)
     expectArraysClose(t2.toFloat32Array(), [1, 9, 2, 10, 5, 13, 6, 14, 3, 11, 4, 12, 7, 15, 8, 16])
   })
-
   /* TODO: FIX - CURRENTLY FAILS (Throws C++ Exception)
     it('5D Tensor [r, c, d, e, f] => [c, r, d, e, f]', () => {
       const t = sm
@@ -134,7 +121,6 @@ describe('transpose', () => {
       )
     })
   */
-
   /* TODO: FIX - CURRENTLY FAILS (Throws C++ Exception)
     it('6D Tensor [r, c, d, e, f] => [r, c, d, f, e]', () => {
       const t = sm
@@ -152,7 +138,6 @@ describe('transpose', () => {
       )
     })
   */
-
   /* TODO: FIX - CURRENTLY FAILS (Throws C++ Exception)
     it('6D Tensor [r, c, d, e, f, g] => [c, r, d, e, f, g]', () => {
       const t = sm
@@ -170,6 +155,5 @@ describe('transpose', () => {
       )
     })
   */
-
   /* TODO: unit tests for gradients */
 })

--- a/test/where.test.ts
+++ b/test/where.test.ts
@@ -1,0 +1,67 @@
+import { /*it,*/ describe /*,expect*/ } from 'bun:test'
+// import * as sm from '@shumai/shumai'
+// import { expectArraysClose, isShape } from './utils'
+
+describe('where', () => {
+  /* TODO: FIX - CURRENTLY FAILS (Throws C++ Exception)
+    it('Scalars', () => {
+      const a = sm.scalar(10)
+      const b = sm.scalar(20)
+      const c = sm.scalar(1)
+      expectArraysClose(sm.where(c, a, b).toFloat32Array(), [10])
+    })
+    it('1D Tensor', () => {
+      const c = sm.tensor(new Float32Array([1, 0, 1, 0]))
+      const a = sm.tensor(new Float32Array([10, 10, 10, 10]))
+      const b = sm.tensor(new Float32Array([20, 20, 20, 20]))
+      expectArraysClose(sm.where(c, a, b).toFloat32Array(), [10, 20, 10, 20])
+    })
+    it('2D Tensor', () => {
+      const c = sm.tensor(new Float32Array([1, 0, 0, 1])).reshape([2, 2])
+      const a = sm.tensor(new Float32Array([10, 10, 10, 10])).reshape([2, 2])
+      const b = sm.tensor(new Float32Array([5, 5, 5, 5])).reshape([2, 2])
+      expectArraysClose(sm.where(c, a, b).toFloat32Array(), [10, 5, 5, 10])
+    })
+    it('broadcasts 2D Tensor shapes', () => {
+      const c = sm.tensor(new Float32Array([1, 0]))
+      let a = sm.tensor(new Float32Array([10, 10])).reshape([2, 1]),
+        b = sm.tensor(new Float32Array([5, 5])).reshape([2, 1]),
+        r = sm.where(c, a, b)
+      expect(isShape(r, [2, 2])).toBe(true)
+      expectArraysClose(sm.where(c, a, b).toFloat32Array(), [10, 5, 10, 5])
+
+      a = sm.tensor(new Float32Array([10, 10, 10, 10, 10, 10])).reshape([2, 3])
+      b = sm.tensor(new Float32Array([5, 5, 5])).reshape([3, 1])
+      r = sm.where(c, a, b)
+      expect(isShape(r, [3, 2])).toBe(true)
+      expectArraysClose(sm.where(c, a, b).toFloat32Array(), [10, 5, 10, 5, 10, 5])
+    })
+    it('3D Tensor', () => {
+      const c = sm.tensor(new Float32Array([1, 0, 1, 0, 0, 0])).reshape([2, 3, 1])
+      const a = sm.tensor(new Float32Array([5, 5, 5, 5, 5, 5])).reshape([2, 3, 1])
+      const b = sm.tensor(new Float32Array([3, 3, 3, 3, 3, 3])).reshape([2, 3, 1])
+      expectArraysClose(sm.where(c, a, b).toFloat32Array(), [5, 3, 5, 3, 3, 3])
+    })
+    it('broadcasts 3D Tensor shapes', () => {
+      const c = sm.tensor(new Float32Array([1, 0]))
+      let a = sm.tensor(new Float32Array([9, 9, 9, 9])).reshape([4, 1, 1]),
+        b = sm.tensor(new Float32Array([8, 8, 8, 8])).reshape([4, 1, 1]),
+        r = sm.where(c, a, b)
+      expect(isShape(r, [4, 1, 2])).toBe(true)
+      expectArraysClose(sm.where(c, a, b).toFloat32Array(), [9, 8, 9, 8, 9, 8, 9, 8])
+
+      a = sm.tensor(new Float32Array([9, 9])).reshape([2, 1])
+      b = sm.tensor(new Float32Array([8, 8, 8, 8])).reshape([4, 1, 1])
+      r = sm.where(c, a, b)
+      expect(isShape(r, [4, 2, 2])).toBe(true)
+      expectArraysClose(sm.where(c, a, b).toFloat32Array(), [9, 8, 9, 8, 9, 8, 9, 8, 9, 8, 9, 8, 9, 8, 9, 8])
+    })
+    it('4D Tensor', () => {
+      const c = sm.tensor(new Float32Array([1, 0, 1, 1])).reshape([2, 2, 1, 1])
+      const a = sm.tensor(new Float32Array([7, 7, 7, 7])).reshape([2, 2, 1, 1])
+      const b = sm.tensor(new Float32Array([3, 3, 3, 3])).reshape([2, 2, 1, 1])
+      expectArraysClose(sm.where(c, a, b).toFloat32Array(), [7, 3, 7, 7])
+    })
+  */
+  /* TODO: unit tests for gradients */
+})


### PR DESCRIPTION
Added unit tests for the following operations: `any`, `cumsum`, `log1p`, `logicalAnd`, `logicalNot`, `logicalOr`, `sqrt`, and `where`.

Note: All tests for `where` are failing with a C++ exception, so I've commented the tests out until we've identified the source of the issue/resolved it (thus ensuring the test run isn't cut short by the C++ exception).