### PR TITLE
Add `axisArg` fn to fix Native Fns that take `axis` as param

### DIFF
--- a/scripts/gen_binding.py
+++ b/scripts/gen_binding.py
@@ -327,7 +327,7 @@ for op, args, ret in op_list:
         elif t == "Axis":
             if not n:
                 n = "axis"
-            c_sig.append(f"{t} {n}")
+            c_sig.append(f"uint32_t {n}")
             c_impl.append(f"auto used_{n} = axisArg({n}, g_row_major, {first_tensor}->ndim());")
             c_op_args.append(f"used_{n}")
             ffi_sig.append("FFIType.u32")

--- a/shumai/cpp/binding_gen.inl
+++ b/shumai/cpp/binding_gen.inl
@@ -202,7 +202,7 @@ void *_clip(void *tensor, void *low, void *high) {
   return t;
 }
 
-void *_roll(void *tensor, int shift, Axis axis) {
+void *_roll(void *tensor, int shift, uint32_t axis) {
   auto *tensor_ptr = reinterpret_cast<fl::Tensor *>(tensor);
   auto used_axis = axisArg(axis, g_row_major, tensor_ptr->ndim());
   auto *t = new fl::Tensor(fl::roll(*tensor_ptr, shift, used_axis));
@@ -461,7 +461,7 @@ void *_amax(void *tensor, void *axes_ptr, int64_t axes_len, bool keep_dims) {
   return t;
 }
 
-void *_argmin(void *tensor, Axis axis, bool keep_dims) {
+void *_argmin(void *tensor, uint32_t axis, bool keep_dims) {
   auto *tensor_ptr = reinterpret_cast<fl::Tensor *>(tensor);
   auto used_axis = axisArg(axis, g_row_major, tensor_ptr->ndim());
   auto *t = new fl::Tensor(fl::argmin(*tensor_ptr, used_axis, keep_dims));
@@ -469,7 +469,7 @@ void *_argmin(void *tensor, Axis axis, bool keep_dims) {
   return t;
 }
 
-void *_argmax(void *tensor, Axis axis, bool keep_dims) {
+void *_argmax(void *tensor, uint32_t axis, bool keep_dims) {
   auto *tensor_ptr = reinterpret_cast<fl::Tensor *>(tensor);
   auto used_axis = axisArg(axis, g_row_major, tensor_ptr->ndim());
   auto *t = new fl::Tensor(fl::argmax(*tensor_ptr, used_axis, keep_dims));
@@ -486,7 +486,7 @@ void *_sum(void *tensor, void *axes_ptr, int64_t axes_len, bool keep_dims) {
   return t;
 }
 
-void *_cumsum(void *tensor, Axis axis) {
+void *_cumsum(void *tensor, uint32_t axis) {
   auto *tensor_ptr = reinterpret_cast<fl::Tensor *>(tensor);
   auto used_axis = axisArg(axis, g_row_major, tensor_ptr->ndim());
   auto *t = new fl::Tensor(fl::cumsum(*tensor_ptr, used_axis));

--- a/shumai/cpp/binding_gen.inl
+++ b/shumai/cpp/binding_gen.inl
@@ -202,9 +202,10 @@ void *_clip(void *tensor, void *low, void *high) {
   return t;
 }
 
-void *_roll(void *tensor, int shift, uint32_t axis) {
+void *_roll(void *tensor, int shift, Axis axis) {
   auto *tensor_ptr = reinterpret_cast<fl::Tensor *>(tensor);
-  auto *t = new fl::Tensor(fl::roll(*tensor_ptr, shift, axis));
+  auto used_axis = axisArg(axis, g_row_major, tensor_ptr->ndim());
+  auto *t = new fl::Tensor(fl::roll(*tensor_ptr, shift, used_axis));
   g_bytes_used += t->bytes();
   return t;
 }
@@ -460,16 +461,18 @@ void *_amax(void *tensor, void *axes_ptr, int64_t axes_len, bool keep_dims) {
   return t;
 }
 
-void *_argmin(void *tensor, uint32_t axis, bool keep_dims) {
+void *_argmin(void *tensor, Axis axis, bool keep_dims) {
   auto *tensor_ptr = reinterpret_cast<fl::Tensor *>(tensor);
-  auto *t = new fl::Tensor(fl::argmin(*tensor_ptr, axis, keep_dims));
+  auto used_axis = axisArg(axis, g_row_major, tensor_ptr->ndim());
+  auto *t = new fl::Tensor(fl::argmin(*tensor_ptr, used_axis, keep_dims));
   g_bytes_used += t->bytes();
   return t;
 }
 
-void *_argmax(void *tensor, uint32_t axis, bool keep_dims) {
+void *_argmax(void *tensor, Axis axis, bool keep_dims) {
   auto *tensor_ptr = reinterpret_cast<fl::Tensor *>(tensor);
-  auto *t = new fl::Tensor(fl::argmax(*tensor_ptr, axis, keep_dims));
+  auto used_axis = axisArg(axis, g_row_major, tensor_ptr->ndim());
+  auto *t = new fl::Tensor(fl::argmax(*tensor_ptr, used_axis, keep_dims));
   g_bytes_used += t->bytes();
   return t;
 }
@@ -483,9 +486,10 @@ void *_sum(void *tensor, void *axes_ptr, int64_t axes_len, bool keep_dims) {
   return t;
 }
 
-void *_cumsum(void *tensor, uint32_t axis) {
+void *_cumsum(void *tensor, Axis axis) {
   auto *tensor_ptr = reinterpret_cast<fl::Tensor *>(tensor);
-  auto *t = new fl::Tensor(fl::cumsum(*tensor_ptr, axis));
+  auto used_axis = axisArg(axis, g_row_major, tensor_ptr->ndim());
+  auto *t = new fl::Tensor(fl::cumsum(*tensor_ptr, used_axis));
   g_bytes_used += t->bytes();
   return t;
 }

--- a/shumai/cpp/flashlight_binding.cc
+++ b/shumai/cpp/flashlight_binding.cc
@@ -27,6 +27,10 @@ std::vector<T> arrayArg(void *ptr, int len, bool reverse, int invert) {
   return out;
 }
 
+uint axisArg(uint axis, bool reverse, int ndim) {
+  return reverse ? ndim - axis - 1 : axis;
+}
+
 static std::atomic<size_t> g_bytes_used = 0;
 static std::atomic<bool> g_row_major = true;
 

--- a/shumai/tensor/tensor_ops_gen.ts
+++ b/shumai/tensor/tensor_ops_gen.ts
@@ -763,7 +763,7 @@ export function clip(tensor: Tensor, low: Tensor, high: Tensor) {
   return t
 }
 
-export function roll(tensor: Tensor, shift: number, axis: number) {
+export function roll(tensor: Tensor, shift: number, axis = 0) {
   const _ptr = fl._roll(
     tensor.ptr,
     shift | 0,
@@ -1093,7 +1093,7 @@ export function amax(tensor: Tensor, axes: BigInt64Array | number[] = [], keep_d
   return t
 }
 
-export function argmin(tensor: Tensor, axis: number, keep_dims = false) {
+export function argmin(tensor: Tensor, axis = 0, keep_dims = false) {
   const _ptr = fl._argmin(
     tensor.ptr,
     axis <= 0 ? 0 : axis >= 0xffffffff ? 0xffffffff : +axis || 0,
@@ -1109,7 +1109,7 @@ export function argmin(tensor: Tensor, axis: number, keep_dims = false) {
   return t
 }
 
-export function argmax(tensor: Tensor, axis: number, keep_dims = false) {
+export function argmax(tensor: Tensor, axis = 0, keep_dims = false) {
   const _ptr = fl._argmax(
     tensor.ptr,
     axis <= 0 ? 0 : axis >= 0xffffffff ? 0xffffffff : +axis || 0,
@@ -1136,7 +1136,7 @@ export function sum(tensor: Tensor, axes: BigInt64Array | number[] = [], keep_di
   return t
 }
 
-export function cumsum(tensor: Tensor, axis: number) {
+export function cumsum(tensor: Tensor, axis = 0) {
   const _ptr = fl._cumsum(tensor.ptr, axis <= 0 ? 0 : axis >= 0xffffffff ? 0xffffffff : +axis || 0)
   const requires_grad = tensor.requires_grad
   const deps = requires_grad

--- a/shumai/tensor/tensor_ops_interface_gen.ts
+++ b/shumai/tensor/tensor_ops_interface_gen.ts
@@ -402,7 +402,7 @@ interface TensorOpsInterface {
   erf(): Tensor
   flip(dim: number): Tensor
   clip(low: Tensor, high: Tensor): Tensor
-  roll(shift: number, axis: number): Tensor
+  roll(shift: number, axis?: number): Tensor
   isnan(): Tensor
   isinf(): Tensor
   sign(): Tensor
@@ -434,10 +434,10 @@ interface TensorOpsInterface {
   matmul(other: Tensor): Tensor
   amin(axes?: BigInt64Array | number[], keep_dims?: boolean): Tensor
   amax(axes?: BigInt64Array | number[], keep_dims?: boolean): Tensor
-  argmin(axis: number, keep_dims?: boolean): Tensor
-  argmax(axis: number, keep_dims?: boolean): Tensor
+  argmin(axis?: number, keep_dims?: boolean): Tensor
+  argmax(axis?: number, keep_dims?: boolean): Tensor
   sum(axes?: BigInt64Array | number[], keep_dims?: boolean): Tensor
-  cumsum(axis: number): Tensor
+  cumsum(axis?: number): Tensor
   mean(axes?: BigInt64Array | number[], keep_dims?: boolean): Tensor
   median(axes?: BigInt64Array | number[], keep_dims?: boolean): Tensor
   var(axes?: BigInt64Array | number[], bias?: boolean, keep_dims?: boolean): Tensor

--- a/shumai/tensor/tensor_ops_shim_gen.ts
+++ b/shumai/tensor/tensor_ops_shim_gen.ts
@@ -230,7 +230,7 @@ export const gen_tensor_op_shim = (_Tensor: new (...args: unknown[]) => Tensor) 
       return t
     },
 
-    roll(shift: number, axis: number) {
+    roll(shift: number, axis = 0) {
       const _ptr = fl._roll(
         this.ptr,
         shift | 0,
@@ -560,7 +560,7 @@ export const gen_tensor_op_shim = (_Tensor: new (...args: unknown[]) => Tensor) 
       return t
     },
 
-    argmin(axis: number, keep_dims = false) {
+    argmin(axis = 0, keep_dims = false) {
       const _ptr = fl._argmin(
         this.ptr,
         axis <= 0 ? 0 : axis >= 0xffffffff ? 0xffffffff : +axis || 0,
@@ -576,7 +576,7 @@ export const gen_tensor_op_shim = (_Tensor: new (...args: unknown[]) => Tensor) 
       return t
     },
 
-    argmax(axis: number, keep_dims = false) {
+    argmax(axis = 0, keep_dims = false) {
       const _ptr = fl._argmax(
         this.ptr,
         axis <= 0 ? 0 : axis >= 0xffffffff ? 0xffffffff : +axis || 0,
@@ -603,7 +603,7 @@ export const gen_tensor_op_shim = (_Tensor: new (...args: unknown[]) => Tensor) 
       return t
     },
 
-    cumsum(axis: number) {
+    cumsum(axis = 0) {
       const _ptr = fl._cumsum(
         this.ptr,
         axis <= 0 ? 0 : axis >= 0xffffffff ? 0xffffffff : +axis || 0


### PR DESCRIPTION
I haven't made the corresponding changes to `scripts/gen_binding.py` as the changes are a bit more involved than the previous updates I've made and I'd rather not screw up the generated code. XD