### PR TITLE
fix isinf test; update coercion rule for int32_t to mirror bun

### DIFF
--- a/scripts/gen_binding.py
+++ b/scripts/gen_binding.py
@@ -15,7 +15,7 @@ coercion_rules = {
     "float": "Math.fround({x})",
     "double": "({x} + 0.00000000000001 - 0.00000000000001)",
     "int": "({x} | 0)",
-    "int32_t": "({x} >= 0xffffffff ? 0xffffffff : +{x} || 0)",
+    "int32_t": "({x} | 0)",
     "uint32_t": "({x} <= 0 ? 0 : {x} >= 0xffffffff ? 0xffffffff : +{x} || 0)",
     "int64_t": "({x}.constructor === BigInt ? {x} : BigInt({x} || 0))",
 }

--- a/shumai/tensor/tensor_ops_gen.ts
+++ b/shumai/tensor/tensor_ops_gen.ts
@@ -764,11 +764,9 @@ export function clip(tensor: Tensor, low: Tensor, high: Tensor) {
 }
 
 export function roll(tensor: Tensor, shift: number, axis: number) {
-  const _ptr = fl._roll(tensor.ptr, shift | 0, axis >= 0xffffffff ? 0xffffffff : +axis || 0)
+  const _ptr = fl._roll(tensor.ptr, shift | 0, axis | 0)
   const requires_grad = tensor.requires_grad
-  const deps = requires_grad
-    ? [tensor, shift | 0, axis >= 0xffffffff ? 0xffffffff : +axis || 0]
-    : []
+  const deps = requires_grad ? [tensor, shift | 0, axis | 0] : []
   const t = new Tensor({ _ptr: _ptr, _deps: deps })
   t.requires_grad = requires_grad
   t.op = 'roll'
@@ -1090,11 +1088,9 @@ export function amax(tensor: Tensor, axes: BigInt64Array | number[] = [], keep_d
 }
 
 export function argmin(tensor: Tensor, axis: number, keep_dims = false) {
-  const _ptr = fl._argmin(tensor.ptr, axis >= 0xffffffff ? 0xffffffff : +axis || 0, !!keep_dims)
+  const _ptr = fl._argmin(tensor.ptr, axis | 0, !!keep_dims)
   const requires_grad = tensor.requires_grad
-  const deps = requires_grad
-    ? [tensor, axis >= 0xffffffff ? 0xffffffff : +axis || 0, !!keep_dims]
-    : []
+  const deps = requires_grad ? [tensor, axis | 0, !!keep_dims] : []
   const t = new Tensor({ _ptr: _ptr, _deps: deps })
   t.requires_grad = requires_grad
   t.op = 'argmin'
@@ -1102,11 +1098,9 @@ export function argmin(tensor: Tensor, axis: number, keep_dims = false) {
 }
 
 export function argmax(tensor: Tensor, axis: number, keep_dims = false) {
-  const _ptr = fl._argmax(tensor.ptr, axis >= 0xffffffff ? 0xffffffff : +axis || 0, !!keep_dims)
+  const _ptr = fl._argmax(tensor.ptr, axis | 0, !!keep_dims)
   const requires_grad = tensor.requires_grad
-  const deps = requires_grad
-    ? [tensor, axis >= 0xffffffff ? 0xffffffff : +axis || 0, !!keep_dims]
-    : []
+  const deps = requires_grad ? [tensor, axis | 0, !!keep_dims] : []
   const t = new Tensor({ _ptr: _ptr, _deps: deps })
   t.requires_grad = requires_grad
   t.op = 'argmax'
@@ -1125,9 +1119,9 @@ export function sum(tensor: Tensor, axes: BigInt64Array | number[] = [], keep_di
 }
 
 export function cumsum(tensor: Tensor, axis: number) {
-  const _ptr = fl._cumsum(tensor.ptr, axis >= 0xffffffff ? 0xffffffff : +axis || 0)
+  const _ptr = fl._cumsum(tensor.ptr, axis | 0)
   const requires_grad = tensor.requires_grad
-  const deps = requires_grad ? [tensor, axis >= 0xffffffff ? 0xffffffff : +axis || 0] : []
+  const deps = requires_grad ? [tensor, axis | 0] : []
   const t = new Tensor({ _ptr: _ptr, _deps: deps })
   t.requires_grad = requires_grad
   t.op = 'cumsum'

--- a/shumai/tensor/tensor_ops_shim_gen.ts
+++ b/shumai/tensor/tensor_ops_shim_gen.ts
@@ -231,11 +231,9 @@ export const gen_tensor_op_shim = (_Tensor: new (...args: unknown[]) => Tensor) 
     },
 
     roll(shift: number, axis: number) {
-      const _ptr = fl._roll(this.ptr, shift | 0, axis >= 0xffffffff ? 0xffffffff : +axis || 0)
+      const _ptr = fl._roll(this.ptr, shift | 0, axis | 0)
       const requires_grad = this.requires_grad
-      const deps = requires_grad
-        ? [this, shift | 0, axis >= 0xffffffff ? 0xffffffff : +axis || 0]
-        : []
+      const deps = requires_grad ? [this, shift | 0, axis | 0] : []
       const t = new _Tensor({ _ptr: _ptr, _deps: deps })
       t.requires_grad = requires_grad
       t.op = 'roll'
@@ -557,11 +555,9 @@ export const gen_tensor_op_shim = (_Tensor: new (...args: unknown[]) => Tensor) 
     },
 
     argmin(axis: number, keep_dims = false) {
-      const _ptr = fl._argmin(this.ptr, axis >= 0xffffffff ? 0xffffffff : +axis || 0, !!keep_dims)
+      const _ptr = fl._argmin(this.ptr, axis | 0, !!keep_dims)
       const requires_grad = this.requires_grad
-      const deps = requires_grad
-        ? [this, axis >= 0xffffffff ? 0xffffffff : +axis || 0, !!keep_dims]
-        : []
+      const deps = requires_grad ? [this, axis | 0, !!keep_dims] : []
       const t = new _Tensor({ _ptr: _ptr, _deps: deps })
       t.requires_grad = requires_grad
       t.op = 'argmin'
@@ -569,11 +565,9 @@ export const gen_tensor_op_shim = (_Tensor: new (...args: unknown[]) => Tensor) 
     },
 
     argmax(axis: number, keep_dims = false) {
-      const _ptr = fl._argmax(this.ptr, axis >= 0xffffffff ? 0xffffffff : +axis || 0, !!keep_dims)
+      const _ptr = fl._argmax(this.ptr, axis | 0, !!keep_dims)
       const requires_grad = this.requires_grad
-      const deps = requires_grad
-        ? [this, axis >= 0xffffffff ? 0xffffffff : +axis || 0, !!keep_dims]
-        : []
+      const deps = requires_grad ? [this, axis | 0, !!keep_dims] : []
       const t = new _Tensor({ _ptr: _ptr, _deps: deps })
       t.requires_grad = requires_grad
       t.op = 'argmax'
@@ -592,9 +586,9 @@ export const gen_tensor_op_shim = (_Tensor: new (...args: unknown[]) => Tensor) 
     },
 
     cumsum(axis: number) {
-      const _ptr = fl._cumsum(this.ptr, axis >= 0xffffffff ? 0xffffffff : +axis || 0)
+      const _ptr = fl._cumsum(this.ptr, axis | 0)
       const requires_grad = this.requires_grad
-      const deps = requires_grad ? [this, axis >= 0xffffffff ? 0xffffffff : +axis || 0] : []
+      const deps = requires_grad ? [this, axis | 0] : []
       const t = new _Tensor({ _ptr: _ptr, _deps: deps })
       t.requires_grad = requires_grad
       t.op = 'cumsum'

--- a/test/isinf.test.ts
+++ b/test/isinf.test.ts
@@ -1,21 +1,17 @@
-import { /*it,*/ describe } from 'bun:test'
-// import * as sm from '@shumai/shumai'
-// import { expectArraysClose } from './utils'
+import { it, describe } from 'bun:test'
+import * as sm from '@shumai/shumai'
+import { expectArraysClose } from './utils'
 
 describe('isinf', () => {
-  /* TODO: FIX - CURRENTLY FAILS (Throws C++ Exception CUDA Backend Only)
-    it('basic', () => {
-      const a = sm.tensor(new Float32Array([Infinity, 3, -Infinity, 1]))
-      const r = sm.isinf(a)
-      expectArraysClose(r.toFloat32Array(), [1, 0, 1, 0])
-    })
-  */
-  /* TODO: FIX - CURRENTLY FAILS (Throws C++ Exception CUDA Backend Only)
-    it('basic with NaN', () => {
-      const a = sm.tensor(new Float32Array([NaN, Infinity, -Infinity, 0, 1]))
-      const r = sm.isnan(a)
-      expectArraysClose(r.toFloat32Array(), [0, 1, 1, 0, 0])
-    })
-  */
+  it('basic', () => {
+    const a = sm.tensor(new Float32Array([Infinity, 3, -Infinity, 1]))
+    const r = sm.isinf(a)
+    expectArraysClose(r.toFloat32Array(), [1, 0, 1, 0])
+  })
+  it('basic with NaN', () => {
+    const a = sm.tensor(new Float32Array([NaN, Infinity, -Infinity, 0, 1]))
+    const r = sm.isinf(a)
+    expectArraysClose(r.toFloat32Array(), [0, 1, 1, 0, 0])
+  })
   /* TODO: unit tests for gradients */
 })

--- a/test/isnan.test.ts
+++ b/test/isnan.test.ts
@@ -3,19 +3,15 @@ import * as sm from '@shumai/shumai'
 import { expectArraysClose } from './utils'
 
 describe('isnan', () => {
-  /* TODO: FIX - CURRENTLY FAILS */
   it('basic', () => {
     const a = sm.tensor(new Float32Array([NaN, 3, 0, 1]))
     const r = sm.isnan(a)
     expectArraysClose(r.toFloat32Array(), [1, 0, 0, 0])
   })
-
-  /* TODO: FIX - CURRENTLY FAILS */
   it('basic with +/- Infinity', () => {
     const a = sm.tensor(new Float32Array([NaN, Infinity, -Infinity, 0, 1]))
     const r = sm.isnan(a)
     expectArraysClose(r.toFloat32Array(), [1, 0, 0, 0, 0])
   })
-
   /* TODO: unit tests for gradients */
 })


### PR DESCRIPTION
Coercion rule for `int32_t` now matches Bun's: https://github.com/oven-sh/bun/blob/206820d27a952e2a7c84da9177ca36d825ee7987/src/bun.js/ffi.exports.js

Fix transpositional error in 2nd `isinf` test, where I'd called `isnan` mistakenly LOL.