### PR TITLE
fix returned JSON structure for `statistics` endpoint

### DIFF
--- a/shumai/io/network.ts
+++ b/shumai/io/network.ts
@@ -225,15 +225,15 @@ export type ServeOpts = {
  */
 export function serve(request_dict: Record<string, any>, options: ServeOpts) {
   const user_data = {}
-  const statistics = {}
+  const statistics: Record<string, number> = {}
 
   const sub_stat_fn = request_dict.statistics ? request_dict.statistics.bind({}) : null
   request_dict.statistics = async (u) => {
     if (sub_stat_fn) {
       const s = await sub_stat_fn(u)
-      return { ...s, ...statistics }
+      return { ...s, statistics }
     }
-    return statistics
+    return { statistics }
   }
   /* TODO: specify a better type than any as its a function */
   const serve_request = async (req: Request, fn: any) => {
@@ -250,6 +250,7 @@ export function serve(request_dict: Record<string, any>, options: ServeOpts) {
       return new Response(encode(ret))
     } else if (ret && ret.constructor === Object) {
       const headers = new Headers([['Content-Type', 'application/json']])
+      headers.set('Access-Control-Allow-Origin', '*')
       return new Response(JSON.stringify(ret), { headers: headers })
     }
     return new Response(ret)


### PR DESCRIPTION
Previously, the JSON returned by `statistics` endpoint destructured the `statistics` property, but the returned JSON is much cleaner if it's structured as this PR proposes. Here's what the resulting JSON looks like with the changes:
![Screen Shot 2022-09-20 at 11 44 24 PM](https://user-images.githubusercontent.com/39316528/191416223-a699ce22-1c1c-49ea-a04d-164f2cd74bba.png)
