### PR TITLE
Add Native Fns to Access `fl::dtype` Enum + `_astype`

### DIFF
--- a/shumai/cpp/flashlight_binding.cc
+++ b/shumai/cpp/flashlight_binding.cc
@@ -176,48 +176,58 @@ int _dtype(void* t) {
   return dtype;
 }
 
-fl::dtype dtypeFloat16() {
-  return fl::dtype::f16;
+int dtypeFloat16() {
+  int dtype = static_cast<int>(fl::dtype::f16);
+  return dtype;
 }
 
-fl::dtype dtypeFloat32() {
-  return fl::dtype::f32;
+int dtypeFloat32() {
+  int dtype = static_cast<int>(fl::dtype::f32);
+  return dtype;
+}
+int dtypeFloat64() {
+  int dtype = static_cast<int>(fl::dtype::f64);
+  return dtype;
 }
 
-fl::dtype dtypeFloat64() {
-  return fl::dtype::f64;
+int dtypeBoolInt8() {
+  int dtype = static_cast<int>(fl::dtype::b8);
+  return dtype;
 }
 
-fl::dtype dtypeBoolInt8() {
-  return fl::dtype::b8;
+int dtypeInt16() {
+  int dtype = static_cast<int>(fl::dtype::s16);
+  return dtype;
 }
 
-fl::dtype dtypeInt16() {
-  return fl::dtype::s16;
+int dtypeInt32() {
+  int dtype = static_cast<int>(fl::dtype::s32);
+  return dtype;
 }
 
-fl::dtype dtypeInt32() {
-  return fl::dtype::s32;
+int dtypeInt64() {
+  int dtype = static_cast<int>(fl::dtype::s64);
+  return dtype;
 }
 
-fl::dtype dtypeInt64() {
-  return fl::dtype::s64;
+int dtypeUint8() {
+  int dtype = static_cast<int>(fl::dtype::u8);
+  return dtype;
 }
 
-fl::dtype dtypeUint8() {
-  return fl::dtype::u8;
+int dtypeUint16() {
+  int dtype = static_cast<int>(fl::dtype::u16);
+  return dtype;
 }
 
-fl::dtype dtypeUint16() {
-  return fl::dtype::u16;
+int dtypeUint32() {
+  int dtype = static_cast<int>(fl::dtype::u32);
+  return dtype;
 }
 
-fl::dtype dtypeUint32() {
-  return fl::dtype::u32;
-}
-
-fl::dtype dtypeUint64() {
-  return fl::dtype::u64;
+int dtypeUint64() {
+  int dtype = static_cast<int>(fl::dtype::u64);
+  return dtype;
 }
 
 float* _float16Buffer(void* t) {

--- a/shumai/cpp/flashlight_binding.cc
+++ b/shumai/cpp/flashlight_binding.cc
@@ -165,9 +165,9 @@ void* _astype(void* t, int type) {
   LOCK_GUARD
   auto dtype = static_cast<fl::dtype>(type);
   auto* tensor = reinterpret_cast<fl::Tensor*>(t);
-  tensor->astype(dtype);
-  g_bytes_used += tensor->bytes();
-  return tensor;
+  auto new_tensor = tensor->astype(dtype);
+  g_bytes_used += new_tensor.bytes();
+  return new fl::Tensor(new_tensor);
 }
 
 int _dtype(void* t) {

--- a/shumai/cpp/flashlight_binding.cc
+++ b/shumai/cpp/flashlight_binding.cc
@@ -161,6 +161,65 @@ int _ndim(void* t) {
   return tensor->ndim();
 }
 
+void* _astype(void* t, int type) {
+  LOCK_GUARD
+  auto dtype = static_cast<fl::dtype>(type);
+  auto* tensor = reinterpret_cast<fl::Tensor*>(t);
+  tensor->astype(dtype);
+  g_bytes_used += tensor->bytes();
+  return tensor;
+}
+
+int _dtype(void* t) {
+  auto* tensor = reinterpret_cast<fl::Tensor*>(t);
+  auto dtype = static_cast<int>(tensor->type());
+  return dtype;
+}
+
+fl::dtype dtypeFloat16() {
+  return fl::dtype::f16;
+}
+
+fl::dtype dtypeFloat32() {
+  return fl::dtype::f32;
+}
+
+fl::dtype dtypeFloat64() {
+  return fl::dtype::f64;
+}
+
+fl::dtype dtypeBoolInt8() {
+  return fl::dtype::b8;
+}
+
+fl::dtype dtypeInt16() {
+  return fl::dtype::s16;
+}
+
+fl::dtype dtypeInt32() {
+  return fl::dtype::s32;
+}
+
+fl::dtype dtypeInt64() {
+  return fl::dtype::s64;
+}
+
+fl::dtype dtypeUint8() {
+  return fl::dtype::u8;
+}
+
+fl::dtype dtypeUint16() {
+  return fl::dtype::u16;
+}
+
+fl::dtype dtypeUint32() {
+  return fl::dtype::u32;
+}
+
+fl::dtype dtypeUint64() {
+  return fl::dtype::u64;
+}
+
 float* _float16Buffer(void* t) {
   LOCK_GUARD
   auto* tensor = reinterpret_cast<fl::Tensor*>(t);

--- a/shumai/ffi/ffi_tensor.ts
+++ b/shumai/ffi/ffi_tensor.ts
@@ -5,6 +5,39 @@ const ffi_tensor = {
   bytesUsed: {
     returns: FFIType.u64
   },
+  dtypeFloat16: {
+    returns: FFIType.int
+  },
+  dtypeFloat32: {
+    returns: FFIType.int
+  },
+  dtypeFloat64: {
+    returns: FFIType.int
+  },
+  dtypeBoolInt8: {
+    returns: FFIType.int
+  },
+  dtypeInt16: {
+    returns: FFIType.int
+  },
+  dtypeInt32: {
+    returns: FFIType.int
+  },
+  dtypeInt64: {
+    returns: FFIType.int
+  },
+  dtypeUint8: {
+    returns: FFIType.int
+  },
+  dtypeUint16: {
+    returns: FFIType.int
+  },
+  dtypeUint32: {
+    returns: FFIType.int
+  },
+  dtypeUint64: {
+    returns: FFIType.int
+  },
   setRowMajor: {},
   setColMajor: {},
   isRowMajor: {
@@ -29,6 +62,10 @@ const ffi_tensor = {
   },
   load: {
     args: [FFIType.cstring],
+    returns: FFIType.ptr
+  },
+  _astype: {
+    args: [FFIType.ptr, FFIType.int],
     returns: FFIType.ptr
   },
   _save: {
@@ -131,6 +168,10 @@ const ffi_tensor = {
     returns: FFIType.u64
   },
   _ndim: {
+    args: [FFIType.ptr],
+    returns: FFIType.i32
+  },
+  _dtype: {
     args: [FFIType.ptr],
     returns: FFIType.i32
   },

--- a/shumai/tensor/tensor.ts
+++ b/shumai/tensor/tensor.ts
@@ -310,7 +310,7 @@ export class Tensor {
     return fl._save(this.ptr, new TextEncoder().encode(filename))
   }
 
-  asType(dtype: dtype) {
+  astype(dtype: dtype) {
     return wrapFLTensor(fl._astype, this.ptr, dtype)
   }
 
@@ -326,7 +326,7 @@ export class Tensor {
     return Number(fl._ndim.native(this.ptr))
   }
 
-  get dType() {
+  get dtype() {
     return Number(fl._dtype.native(this.ptr))
   }
 

--- a/shumai/tensor/tensor.ts
+++ b/shumai/tensor/tensor.ts
@@ -10,19 +10,19 @@ import type { OpStats } from '../io'
 fl.init.native()
 
 export enum dtype {
-  Float16 = fl.dtypeFloat16.native(),
-  Float32 = fl.dtypeFloat32.native(),
-  Float64 = fl.dtypeFloat64.native(),
-  BoolInt8 = fl.dtypeBoolInt8.native(),
-  Int16 = fl.dtypeInt16.native(),
-  Int32 = fl.dtypeInt32.native(),
-  Int64 = fl.dtypeInt64.native(),
-  BigInt64 = fl.dtypeInt64.native(),
-  Uint8 = fl.dtypeUint8.native(),
-  Uint16 = fl.dtypeUint16.native(),
-  Uint32 = fl.dtypeUint32.native(),
-  Uint64 = fl.dtypeUint64.native(),
-  BigUint64 = fl.dtypeUint64.native()
+  Float16 = Number(fl.dtypeFloat16.native()),
+  Float32 = Number(fl.dtypeFloat32.native()),
+  Float64 = Number(fl.dtypeFloat64.native()),
+  BoolInt8 = Number(fl.dtypeBoolInt8.native()),
+  Int16 = Number(fl.dtypeInt16.native()),
+  Int32 = Number(fl.dtypeInt32.native()),
+  Int64 = Number(fl.dtypeInt64.native()),
+  BigInt64 = Number(fl.dtypeInt64.native()),
+  Uint8 = Number(fl.dtypeUint8.native()),
+  Uint16 = Number(fl.dtypeUint16.native()),
+  Uint32 = Number(fl.dtypeUint32.native()),
+  Uint64 = Number(fl.dtypeUint64.native()),
+  BigUint64 = Number(fl.dtypeUint64.native())
 }
 /** @private */
 export const gradient_functions: { [key: string]: CallableFunction } = {}
@@ -311,7 +311,7 @@ export class Tensor {
   }
 
   asType(dtype: dtype) {
-    return wrapFLTensor(fl._astype.native, this.ptr, dtype)
+    return wrapFLTensor(fl._astype, this.ptr, dtype)
   }
 
   eval() {

--- a/shumai/tensor/tensor.ts
+++ b/shumai/tensor/tensor.ts
@@ -8,6 +8,22 @@ import { getStack, collectStats } from './stats'
 import type { OpStats } from '../io'
 
 fl.init.native()
+
+export enum dtype {
+  Float16 = fl.dtypeFloat16.native(),
+  Float32 = fl.dtypeFloat32.native(),
+  Float64 = fl.dtypeFloat64.native(),
+  BoolInt8 = fl.dtypeBoolInt8.native(),
+  Int16 = fl.dtypeInt16.native(),
+  Int32 = fl.dtypeInt32.native(),
+  Int64 = fl.dtypeInt64.native(),
+  BigInt64 = fl.dtypeInt64.native(),
+  Uint8 = fl.dtypeUint8.native(),
+  Uint16 = fl.dtypeUint16.native(),
+  Uint32 = fl.dtypeUint32.native(),
+  Uint64 = fl.dtypeUint64.native(),
+  BigUint64 = fl.dtypeUint64.native()
+}
 /** @private */
 export const gradient_functions: { [key: string]: CallableFunction } = {}
 
@@ -263,7 +279,7 @@ export class Tensor {
       this.deps = obj._deps
       return
     }
-    if (obj.constructor === String) {
+    if (typeof obj === 'string') {
       this._injest_ptr(fl.load(new TextEncoder().encode(obj)))
       return
     }
@@ -273,7 +289,7 @@ export class Tensor {
       this._injest_ptr(fl.tensorFromBuffer.native(len, ptr(obj)))
       return
     }
-    if (obj.constructor === Number) {
+    if (typeof obj === 'number') {
       obj = [obj]
     }
     this._injest_ptr(fl.createTensor.native(...arrayArg(obj, FFIType.i64)))
@@ -304,6 +320,10 @@ export class Tensor {
 
   get ndim() {
     return Number(fl._ndim.native(this.ptr))
+  }
+
+  get dType() {
+    return Number(fl._dtype.native(this.ptr))
   }
 
   get shape() {
@@ -511,25 +531,25 @@ export function tensor(obj) {
 /**
  * @returns The current number of bytes allocated and managed by Shumai.
  */
-export function bytesUsed() {
+export function bytesUsed(): bigint {
   return fl.bytesUsed.native()
 }
 
 export const layout = {
   /** Set the framework layout to be row major (default). */
   setRowMajor: () => {
-    fl.setRowMajor()
+    fl.setRowMajor.native()
   },
   /** Set the framework layout to be column major. */
   setColMajor: () => {
-    fl.setColMajor()
+    fl.setColMajor.native()
   },
   /** Return true if the framework is currently row major. */
   isRowMajor: (): boolean => {
-    return fl.isRowMajor()
+    return fl.isRowMajor.native()
   },
   /** Return true if the framework is currently column major. */
   isColMajor: (): boolean => {
-    return !fl.isRowMajor()
+    return !fl.isRowMajor.native()
   }
 }

--- a/shumai/tensor/tensor.ts
+++ b/shumai/tensor/tensor.ts
@@ -310,6 +310,10 @@ export class Tensor {
     return fl._save(this.ptr, new TextEncoder().encode(filename))
   }
 
+  asType(dtype: dtype) {
+    return wrapFLTensor(fl._astype.native, this.ptr, dtype)
+  }
+
   eval() {
     return fl._eval.native(this.ptr)
   }

--- a/test/conv.test.ts
+++ b/test/conv.test.ts
@@ -1,0 +1,27 @@
+import * as sm from '@shumai/shumai'
+import { it, describe, expect } from 'bun:test'
+import { expectArraysClose, isShape } from './utils'
+
+describe('conv', () => {
+  it('simple', () => {
+    const x = sm.full([1, 1, 4, 4], 1)
+    const w = sm.full([1, 1, 3, 3], 1)
+    const y = sm.conv2d(x, w)
+    expect(isShape(y, [1, 1, 2, 2])).toBe(true)
+    expectArraysClose(y.toFloat32Array(), sm.full([2, 2], 9).toFloat32Array())
+  })
+  it('padded', () => {
+    const x = sm.full([1, 1, 3, 3], 1)
+    const w = sm.full([1, 1, 3, 3], 1)
+    const y = sm.conv2d(x, w, 1, 1, 1, 1)
+    expect(isShape(y, [1, 1, 3, 3])).toBe(true)
+    expectArraysClose(y.toFloat32Array(), new Float32Array([4, 6, 4, 6, 9, 6, 4, 6, 4]))
+  })
+  it('strided', () => {
+    const x = sm.full([1, 1, 6, 6], 1)
+    const w = sm.full([1, 1, 3, 3], 1)
+    const y = sm.conv2d(x, w, 1, 1, 0, 0, 2, 2)
+    expect(isShape(y, [1, 1, 2, 2])).toBe(true)
+    expectArraysClose(y.toFloat32Array(), sm.full([2, 2], 9).toFloat32Array())
+  })
+})

--- a/test/dtype.test.ts
+++ b/test/dtype.test.ts
@@ -1,0 +1,15 @@
+import { it, describe, expect } from 'bun:test'
+import * as sm from '@shumai/shumai'
+
+describe('asType/dType', () => {
+  it('basic', () => {
+    const t = sm.tensor(new Float32Array([-0.25, 0.25, 0.5, 0.75, -0.4])).asType(sm.dtype.Float64)
+    expect(t.dType).toBe(sm.dtype.Float64)
+
+    const t2 = t.asType(sm.dtype.Int32)
+    expect(t2.dType).toBe(sm.dtype.Int32)
+
+    const t3 = t2.asType(sm.dtype.Float32)
+    expect(t3.dType).toBe(sm.dtype.Float32)
+  })
+})

--- a/test/dtype.test.ts
+++ b/test/dtype.test.ts
@@ -3,13 +3,17 @@ import * as sm from '@shumai/shumai'
 
 describe('asType/dType', () => {
   it('basic', () => {
-    const t = sm.tensor(new Float32Array([-0.25, 0.25, 0.5, 0.75, -0.4])).asType(sm.dtype.Float64)
-    expect(t.dType).toBe(sm.dtype.Float64)
+    for (let i = 0; i < 256; i++) {
+      const t = sm
+        .tensor(new Float32Array(new Array(10).map(() => Math.random())))
+        .asType(sm.dtype.Float64)
+      expect(t.dType).toBe(sm.dtype.Float64)
 
-    const t2 = t.asType(sm.dtype.Int32)
-    expect(t2.dType).toBe(sm.dtype.Int32)
+      const t2 = t.asType(sm.dtype.Int32)
+      expect(t2.dType).toBe(sm.dtype.Int32)
 
-    const t3 = t2.asType(sm.dtype.Float32)
-    expect(t3.dType).toBe(sm.dtype.Float32)
+      const t3 = t2.asType(sm.dtype.Float32)
+      expect(t3.dType).toBe(sm.dtype.Float32)
+    }
   })
 })

--- a/test/dtype.test.ts
+++ b/test/dtype.test.ts
@@ -6,14 +6,14 @@ describe('asType/dType', () => {
     for (let i = 0; i < 256; i++) {
       const t = sm
         .tensor(new Float32Array(new Array(10).map(() => Math.random())))
-        .asType(sm.dtype.Float64)
-      expect(t.dType).toBe(sm.dtype.Float64)
+        .astype(sm.dtype.Float64)
+      expect(t.dtype).toBe(sm.dtype.Float64)
 
-      const t2 = t.asType(sm.dtype.Int32)
-      expect(t2.dType).toBe(sm.dtype.Int32)
+      const t2 = t.astype(sm.dtype.Int32)
+      expect(t2.dtype).toBe(sm.dtype.Int32)
 
-      const t3 = t2.asType(sm.dtype.Float32)
-      expect(t3.dType).toBe(sm.dtype.Float32)
+      const t3 = t2.astype(sm.dtype.Float32)
+      expect(t3.dtype).toBe(sm.dtype.Float32)
     }
   })
 })


### PR DESCRIPTION
Begin implementing functionality to allow control of type underlying tensor data.

In testing, tensor class method `asType` (and similar variations):

```ts
  asType(dtype: dtype) {
    fl._astype.native(this.ptr, dtype)
  }
  ``` 
  
  were failing to update the type accordingly in the following test:
  ```ts
  const t = sm.tensor(new Float32Array([1, 2, 3]))
  t.asType(sm.dtype.Float64)
  console.log(t.dType === sm.dtype.Float64, t.dType, sm.dtype.Float64)
  ```
  Outputs:
  `false, 1, 2`

As such, I've temporarily removed the `asType` tensor class method pending feedback; if it requires more involved changes to the Tensor class, it might be better to submit as a separate PR as this one is getting a bit crowded.