### PR TITLE
update `gen_binding.py` so native fn `_where` casts param `cond` to `fl::dtype::b8`

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,14 +20,14 @@
     "ai"
   ],
   "devDependencies": {
-    "@typescript-eslint/eslint-plugin": "^5.38.0",
-    "@typescript-eslint/parser": "^5.38.0",
+    "@typescript-eslint/eslint-plugin": "^5.39.0",
+    "@typescript-eslint/parser": "^5.39.0",
     "bun-types": "^0.1.11",
-    "eslint": "^8.23.1",
+    "eslint": "^8.24.0",
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-prettier": "^4.2.1",
     "prettier": "^2.7.1",
-    "typescript": "^4.8.3",
+    "typescript": "^4.8.4",
     "typedoc": "^0.23.14",
     "typedoc-plugin-katex": "^0.1.2"
   },

--- a/scripts/gen_binding.py
+++ b/scripts/gen_binding.py
@@ -418,7 +418,10 @@ for op, args, ret in op_list:
           c_impl.append(f"g_bytes_used += t.bytes();")
           c_impl.append(f"return new fl::Tensor(t);")
           c_impl.append("} else {")
-        c_impl.append(f"auto t = fl::{op}({c_args});")
+        if op == 'where':
+          c_impl.append(f"auto t = fl::{op}({c_args.split(',')[0]}->astype(fl::dtype::b8), {','.join(c_args.split(',')[1:])});")
+        else:
+          c_impl.append(f"auto t = fl::{op}({c_args});")
         if op in c_overwrites and not methods_only:
           c_impl.append(c_overwrites[op](c_op_args))
         if fix_keep_dims:

--- a/scripts/gen_binding.py
+++ b/scripts/gen_binding.py
@@ -323,7 +323,10 @@ for op, args, ret in op_list:
             c_impl.append(f"auto *{n}_ptr = reinterpret_cast<fl::Tensor*>({n});")
             if not first_tensor:
                 first_tensor = f"{n}_ptr"
-            c_op_args.append(f"*{n}_ptr")
+            if op == 'where' and n == 'cond':
+                c_op_args.append(f"{n}_ptr->astype(fl::dtype::b8)")
+            else:
+                c_op_args.append(f"*{n}_ptr")
         elif t == "Shape":
             if not n:
                 n = "shape"
@@ -418,10 +421,7 @@ for op, args, ret in op_list:
           c_impl.append(f"g_bytes_used += t.bytes();")
           c_impl.append(f"return new fl::Tensor(t);")
           c_impl.append("} else {")
-        if op == 'where':
-          c_impl.append(f"auto t = fl::{op}({c_args.split(',')[0][1:]}->astype(fl::dtype::b8), {','.join(c_args.split(',')[1:])});")
-        else:
-          c_impl.append(f"auto t = fl::{op}({c_args});")
+        c_impl.append(f"auto t = fl::{op}({c_args});")
         if op in c_overwrites and not methods_only:
           c_impl.append(c_overwrites[op](c_op_args))
         if fix_keep_dims:

--- a/scripts/gen_binding.py
+++ b/scripts/gen_binding.py
@@ -419,7 +419,7 @@ for op, args, ret in op_list:
           c_impl.append(f"return new fl::Tensor(t);")
           c_impl.append("} else {")
         if op == 'where':
-          c_impl.append(f"auto t = fl::{op}({c_args.split(',')[0]}->astype(fl::dtype::b8), {','.join(c_args.split(',')[1:])});")
+          c_impl.append(f"auto t = fl::{op}({c_args.split(',')[0][1:]}->astype(fl::dtype::b8), {','.join(c_args.split(',')[1:])});")
         else:
           c_impl.append(f"auto t = fl::{op}({c_args});")
         if op in c_overwrites and not methods_only:

--- a/shumai/cpp/binding_gen.inl
+++ b/shumai/cpp/binding_gen.inl
@@ -312,7 +312,7 @@ void* _where(void* cond, void* x, void* y) {
   auto* cond_ptr = reinterpret_cast<fl::Tensor*>(cond);
   auto* x_ptr = reinterpret_cast<fl::Tensor*>(x);
   auto* y_ptr = reinterpret_cast<fl::Tensor*>(y);
-  auto t = fl::where(*cond_ptr->astype(fl::dtype::b8), *x_ptr, *y_ptr);
+  auto t = fl::where(cond_ptr->astype(fl::dtype::b8), *x_ptr, *y_ptr);
   g_bytes_used += t.bytes();
   return new fl::Tensor(t);
 }

--- a/shumai/cpp/binding_gen.inl
+++ b/shumai/cpp/binding_gen.inl
@@ -312,7 +312,7 @@ void* _where(void* cond, void* x, void* y) {
   auto* cond_ptr = reinterpret_cast<fl::Tensor*>(cond);
   auto* x_ptr = reinterpret_cast<fl::Tensor*>(x);
   auto* y_ptr = reinterpret_cast<fl::Tensor*>(y);
-  auto t = fl::where(*cond_ptr, *x_ptr, *y_ptr);
+  auto t = fl::where(*cond_ptr->astype(fl::dtype::b8), *x_ptr, *y_ptr);
   g_bytes_used += t.bytes();
   return new fl::Tensor(t);
 }

--- a/test/where.test.ts
+++ b/test/where.test.ts
@@ -1,27 +1,27 @@
-import { /*it,*/ describe /*,expect*/ } from 'bun:test'
-// import * as sm from '@shumai/shumai'
-// import { expectArraysClose, isShape } from './utils'
+import { it, describe /*,expect*/ } from 'bun:test'
+import * as sm from '@shumai/shumai'
+import { expectArraysClose /*, isShape*/ } from './utils'
 
 describe('where', () => {
+  it('Scalars', () => {
+    const a = sm.scalar(10)
+    const b = sm.scalar(20)
+    const c = sm.scalar(1)
+    expectArraysClose(sm.where(c, a, b).toFloat32Array(), [10])
+  })
+  it('1D Tensor', () => {
+    const c = sm.tensor(new Float32Array([1, 0, 1, 0]))
+    const a = sm.tensor(new Float32Array([10, 10, 10, 10]))
+    const b = sm.tensor(new Float32Array([20, 20, 20, 20]))
+    expectArraysClose(sm.where(c, a, b).toFloat32Array(), [10, 20, 10, 20])
+  })
+  it('2D Tensor', () => {
+    const c = sm.tensor(new Float32Array([1, 0, 0, 1])).reshape([2, 2])
+    const a = sm.tensor(new Float32Array([10, 10, 10, 10])).reshape([2, 2])
+    const b = sm.tensor(new Float32Array([5, 5, 5, 5])).reshape([2, 2])
+    expectArraysClose(sm.where(c, a, b).toFloat32Array(), [10, 5, 5, 10])
+  })
   /* TODO: FIX - CURRENTLY FAILS (Throws C++ Exception)
-    it('Scalars', () => {
-      const a = sm.scalar(10)
-      const b = sm.scalar(20)
-      const c = sm.scalar(1)
-      expectArraysClose(sm.where(c, a, b).toFloat32Array(), [10])
-    })
-    it('1D Tensor', () => {
-      const c = sm.tensor(new Float32Array([1, 0, 1, 0]))
-      const a = sm.tensor(new Float32Array([10, 10, 10, 10]))
-      const b = sm.tensor(new Float32Array([20, 20, 20, 20]))
-      expectArraysClose(sm.where(c, a, b).toFloat32Array(), [10, 20, 10, 20])
-    })
-    it('2D Tensor', () => {
-      const c = sm.tensor(new Float32Array([1, 0, 0, 1])).reshape([2, 2])
-      const a = sm.tensor(new Float32Array([10, 10, 10, 10])).reshape([2, 2])
-      const b = sm.tensor(new Float32Array([5, 5, 5, 5])).reshape([2, 2])
-      expectArraysClose(sm.where(c, a, b).toFloat32Array(), [10, 5, 5, 10])
-    })
     it('broadcasts 2D Tensor shapes', () => {
       const c = sm.tensor(new Float32Array([1, 0]))
       let a = sm.tensor(new Float32Array([10, 10])).reshape([2, 1]),
@@ -36,12 +36,14 @@ describe('where', () => {
       expect(isShape(r, [3, 2])).toBe(true)
       expectArraysClose(sm.where(c, a, b).toFloat32Array(), [10, 5, 10, 5, 10, 5])
     })
-    it('3D Tensor', () => {
-      const c = sm.tensor(new Float32Array([1, 0, 1, 0, 0, 0])).reshape([2, 3, 1])
-      const a = sm.tensor(new Float32Array([5, 5, 5, 5, 5, 5])).reshape([2, 3, 1])
-      const b = sm.tensor(new Float32Array([3, 3, 3, 3, 3, 3])).reshape([2, 3, 1])
-      expectArraysClose(sm.where(c, a, b).toFloat32Array(), [5, 3, 5, 3, 3, 3])
-    })
+  */
+  it('3D Tensor', () => {
+    const c = sm.tensor(new Float32Array([1, 0, 1, 0, 0, 0])).reshape([2, 3, 1])
+    const a = sm.tensor(new Float32Array([5, 5, 5, 5, 5, 5])).reshape([2, 3, 1])
+    const b = sm.tensor(new Float32Array([3, 3, 3, 3, 3, 3])).reshape([2, 3, 1])
+    expectArraysClose(sm.where(c, a, b).toFloat32Array(), [5, 3, 5, 3, 3, 3])
+  })
+  /* TODO: FIX - CURRENTLY FAILS (Throws C++ Exception)
     it('broadcasts 3D Tensor shapes', () => {
       const c = sm.tensor(new Float32Array([1, 0]))
       let a = sm.tensor(new Float32Array([9, 9, 9, 9])).reshape([4, 1, 1]),
@@ -56,12 +58,13 @@ describe('where', () => {
       expect(isShape(r, [4, 2, 2])).toBe(true)
       expectArraysClose(sm.where(c, a, b).toFloat32Array(), [9, 8, 9, 8, 9, 8, 9, 8, 9, 8, 9, 8, 9, 8, 9, 8])
     })
-    it('4D Tensor', () => {
-      const c = sm.tensor(new Float32Array([1, 0, 1, 1])).reshape([2, 2, 1, 1])
-      const a = sm.tensor(new Float32Array([7, 7, 7, 7])).reshape([2, 2, 1, 1])
-      const b = sm.tensor(new Float32Array([3, 3, 3, 3])).reshape([2, 2, 1, 1])
-      expectArraysClose(sm.where(c, a, b).toFloat32Array(), [7, 3, 7, 7])
-    })
   */
+
+  it('4D Tensor', () => {
+    const c = sm.tensor(new Float32Array([1, 0, 1, 1])).reshape([2, 2, 1, 1])
+    const a = sm.tensor(new Float32Array([7, 7, 7, 7])).reshape([2, 2, 1, 1])
+    const b = sm.tensor(new Float32Array([3, 3, 3, 3])).reshape([2, 2, 1, 1])
+    expectArraysClose(sm.where(c, a, b).toFloat32Array(), [7, 3, 7, 7])
+  })
   /* TODO: unit tests for gradients */
 })


### PR DESCRIPTION
Updated dependencies (namely ESLint/related Typescript reps); additionally, spent time debugging the failing `where` tests, which led me to identify that Flashlight expects parameter `cond` to have `dtype::b8`; accordingly, updated `gen_binding.py` so that the generated typescript `where` methods both check if `cond.dtype === dtype.BoolInt8`, calling `cond = cond.astype(dtype.BoolInt8)` to convert if the type is inaccurate.