### PR TITLE
Fallback to CPU versions automatically

### DIFF
--- a/shumai/ffi/ffi_flashlight.ts
+++ b/shumai/ffi/ffi_flashlight.ts
@@ -4,41 +4,59 @@ import { cwd } from 'process'
 import { ffi_tensor } from './ffi_tensor'
 import { ffi_tensor_ops } from './ffi_tensor_ops_gen'
 
-const pkgname = `@shumai/${process.platform}_${process.arch}_shumai_flashlight`
-const BINDING_NAME_PREFIX = 'libflashlight_binding'
-const path = (() => {
-  // If we find libflashlight_binding in the project root, use that instead of
-  // an installed version of the library
-  const local_path = `${cwd()}/${BINDING_NAME_PREFIX}.${suffix}`
-  if (existsSync(local_path)) {
-    return local_path
-  }
-  return import.meta.resolveSync(`${pkgname}/${BINDING_NAME_PREFIX}.${suffix}`)
-})()
+const pkg_paths = [
+  `@shumai/${process.platform}_${process.arch}_shumai_flashlight`,
+  `@shumai/${process.platform}_${process.arch}_shumai_flashlight_cpu`
+]
+const shared_lib = `libflashlight_binding.${suffix}`
 
-const { symbols: fl } = (() => {
+const files_to_attempt = []
+
+// If we find libflashlight_binding in the project root, use that instead of
+// an installed version of the library
+const local_path = `${cwd()}/${shared_lib}`
+if (existsSync(local_path)) {
+  files_to_attempt.push(local_path)
+}
+
+for (const pkg_path of pkg_paths) {
   try {
-    return dlopen(path, {
+    files_to_attempt.push(import.meta.resolveSync(`${pkg_path}/${shared_lib}`))
+  } catch (e) {}
+}
+
+let fl = null
+let NATIVE_FILE = null
+
+for (const file of files_to_attempt) {
+  try {
+    const { symbols: _fl } = dlopen(file, {
       ...ffi_tensor,
       ...ffi_tensor_ops
     })
+    fl = _fl
+    NATIVE_FILE = file
+    break
   } catch (error) {
-    console.error('Bun trace:', error)
-    throw new Error(`shumai was unable to load backing libraries!
-    Make sure a valid tensor backend (e.g. ArrayFire) is installed by running,
-    for example:
-      ${process.platform === 'darwin' ? 'brew install arrayfire' : ''}
-      ${process.platform === 'linux' ? 'sudo apt install arrayfire-cuda3-cuda-11-6' : ''}
-
-    or see the ArrayFire documentation
-    (https://github.com/arrayfire/arrayfire/wiki/Getting-ArrayFire)
-    for installing on your OS / distribution.
-
-    If you're still having trouble, please create an issue
-    (https://github.com/facebookresearch/shumai/issues)
-    outlining your system and platform details.
-    `)
+    console.log(`warning: couldn't load ${file}, falling back...`)
   }
-})()
+}
 
-export { fl }
+if (!fl) {
+  throw new Error(`shumai was unable to load backing libraries!
+  Make sure a valid tensor backend (e.g. ArrayFire) is installed by running,
+  for example:
+    ${process.platform === 'darwin' ? 'brew install arrayfire' : ''}
+    ${process.platform === 'linux' ? 'sudo apt install arrayfire-cuda3-cuda-11-6' : ''}
+
+  or see the ArrayFire documentation
+  (https://github.com/arrayfire/arrayfire/wiki/Getting-ArrayFire)
+  for installing on your OS / distribution.
+
+  If you're still having trouble, please create an issue
+  (https://github.com/facebookresearch/shumai/issues)
+  outlining your system and platform details.
+  `)
+}
+
+export { fl, NATIVE_FILE }

--- a/shumai/tensor/tensor.ts
+++ b/shumai/tensor/tensor.ts
@@ -6,6 +6,7 @@ import { full } from './tensor_ops_gen'
 import { gen_tensor_op_shim } from './tensor_ops_shim_gen'
 import { getStack, collectStats } from './stats'
 import type { OpStats } from '../io'
+export { NATIVE_FILE } from '../ffi/ffi_flashlight'
 
 fl.init.native()
 


### PR DESCRIPTION
This should simplify installation by allowing folks to install various versions of the native bindings (with fallbacks automatically used)