### PR TITLE
add `expectThrows` test util

### DIFF
--- a/test/utils.ts
+++ b/test/utils.ts
@@ -36,6 +36,30 @@ export const areSameShape = (t1: Tensor, t2: Tensor) => {
   return true
 }
 
+export const expectThrows = (
+  fn: CallableFunction,
+  exp?: Error['message'] | RegExp | CallableFunction,
+  msg?: Error['message']
+) => {
+  let isErr = false
+  if (!msg && typeof exp === 'string') {
+    msg = exp
+    exp = null
+  }
+  try {
+    fn()
+  } catch (err) {
+    isErr = true
+
+    if (typeof exp === 'function') {
+      expect(exp(err)).toBe(true)
+    } else if (exp instanceof RegExp) {
+      expect(exp.test(err.message)).toBe(true)
+    }
+  }
+  return expect(isErr).toBe(true)
+}
+
 export const isClose = (actual: number | bigint, expected: number | bigint, error = 0.001) => {
   if (typeof actual !== typeof expected) return false
 


### PR DESCRIPTION
Add `expectThrows` test function that can be used to test a. that the function passed in as a param throws and b. optionally pass in params to validate that it's throwing the type of error you expect.

Given that whether we want to make use of this on currently commented out tests (not yet fully implemented/ArrayFire not supporting >4 Dims) is a matter of preference, I haven't called the new `expectThrows` fn in any of the unit tests, but here's a snippet demonstrating how to use:

```ts
it('simple', () => {
    expectThrows(() => {
      const x = sm.full([1, 1, 4, 4], 1)
      const w = sm.full([1, 1, 3, 3], 1)
      const y = sm.conv2d(x, w)
      expect(isShape(y, [1, 1, 2, 2])).toBe(true)
      expectArraysClose(y.toFloat32Array(), sm.full([2, 2], 9).toFloat32Array())
    })
})
```