### PR TITLE
`HANDLE_EXCEPTION` for remaining native Fns returning pointer

### DIFF
--- a/scripts/gen_binding.py
+++ b/scripts/gen_binding.py
@@ -511,7 +511,7 @@ for op, args, ret in op_list:
   try {{
     {c_impl_str}
   }} catch (std::exception const& e) {{
-    HANDLE_EXCEPTION(e, "_{op}");
+    HANDLE_EXCEPTION(e);
   }}
 }}"""
     full_js.append(js)

--- a/shumai/cpp/binding_gen.inl
+++ b/shumai/cpp/binding_gen.inl
@@ -8,7 +8,7 @@ void* _rand(void* shape_ptr, int64_t shape_len) {
     g_bytes_used += t.bytes();
     return new fl::Tensor(t);
   } catch (std::exception const& e) {
-    HANDLE_EXCEPTION(e, "_rand");
+    HANDLE_EXCEPTION(e);
   }
 }
 
@@ -21,7 +21,7 @@ void* _randn(void* shape_ptr, int64_t shape_len) {
     g_bytes_used += t.bytes();
     return new fl::Tensor(t);
   } catch (std::exception const& e) {
-    HANDLE_EXCEPTION(e, "_randn");
+    HANDLE_EXCEPTION(e);
   }
 }
 
@@ -34,7 +34,7 @@ void* _full(void* shape_ptr, int64_t shape_len, float val) {
     g_bytes_used += t.bytes();
     return new fl::Tensor(t);
   } catch (std::exception const& e) {
-    HANDLE_EXCEPTION(e, "_full");
+    HANDLE_EXCEPTION(e);
   }
 }
 
@@ -46,7 +46,7 @@ void* _identity(int64_t dim) {
     g_bytes_used += t.bytes();
     return new fl::Tensor(t);
   } catch (std::exception const& e) {
-    HANDLE_EXCEPTION(e, "_identity");
+    HANDLE_EXCEPTION(e);
   }
 }
 
@@ -58,7 +58,7 @@ void* _arange(float start, float end, float step) {
     g_bytes_used += t.bytes();
     return new fl::Tensor(t);
   } catch (std::exception const& e) {
-    HANDLE_EXCEPTION(e, "_arange");
+    HANDLE_EXCEPTION(e);
   }
 }
 
@@ -76,7 +76,7 @@ void* _iota(void* dims_ptr,
     g_bytes_used += t.bytes();
     return new fl::Tensor(t);
   } catch (std::exception const& e) {
-    HANDLE_EXCEPTION(e, "_iota");
+    HANDLE_EXCEPTION(e);
   }
 }
 
@@ -90,7 +90,7 @@ void* _reshape(void* tensor, void* shape_ptr, int64_t shape_len) {
     g_bytes_used += t.bytes();
     return new fl::Tensor(t);
   } catch (std::exception const& e) {
-    HANDLE_EXCEPTION(e, "_reshape");
+    HANDLE_EXCEPTION(e);
   }
 }
 
@@ -105,7 +105,7 @@ void* _transpose(void* tensor, void* axes_ptr, int64_t axes_len) {
     g_bytes_used += t.bytes();
     return new fl::Tensor(t);
   } catch (std::exception const& e) {
-    HANDLE_EXCEPTION(e, "_transpose");
+    HANDLE_EXCEPTION(e);
   }
 }
 
@@ -119,7 +119,7 @@ void* _tile(void* tensor, void* shape_ptr, int64_t shape_len) {
     g_bytes_used += t.bytes();
     return new fl::Tensor(t);
   } catch (std::exception const& e) {
-    HANDLE_EXCEPTION(e, "_tile");
+    HANDLE_EXCEPTION(e);
   }
 }
 
@@ -132,7 +132,7 @@ void* _nonzero(void* tensor) {
     g_bytes_used += t.bytes();
     return new fl::Tensor(t);
   } catch (std::exception const& e) {
-    HANDLE_EXCEPTION(e, "_nonzero");
+    HANDLE_EXCEPTION(e);
   }
 }
 
@@ -145,7 +145,7 @@ void* _negative(void* tensor) {
     g_bytes_used += t.bytes();
     return new fl::Tensor(t);
   } catch (std::exception const& e) {
-    HANDLE_EXCEPTION(e, "_negative");
+    HANDLE_EXCEPTION(e);
   }
 }
 
@@ -158,7 +158,7 @@ void* _logicalNot(void* tensor) {
     g_bytes_used += t.bytes();
     return new fl::Tensor(t);
   } catch (std::exception const& e) {
-    HANDLE_EXCEPTION(e, "_logicalNot");
+    HANDLE_EXCEPTION(e);
   }
 }
 
@@ -171,7 +171,7 @@ void* _exp(void* tensor) {
     g_bytes_used += t.bytes();
     return new fl::Tensor(t);
   } catch (std::exception const& e) {
-    HANDLE_EXCEPTION(e, "_exp");
+    HANDLE_EXCEPTION(e);
   }
 }
 
@@ -184,7 +184,7 @@ void* _log(void* tensor) {
     g_bytes_used += t.bytes();
     return new fl::Tensor(t);
   } catch (std::exception const& e) {
-    HANDLE_EXCEPTION(e, "_log");
+    HANDLE_EXCEPTION(e);
   }
 }
 
@@ -197,7 +197,7 @@ void* _log1p(void* tensor) {
     g_bytes_used += t.bytes();
     return new fl::Tensor(t);
   } catch (std::exception const& e) {
-    HANDLE_EXCEPTION(e, "_log1p");
+    HANDLE_EXCEPTION(e);
   }
 }
 
@@ -210,7 +210,7 @@ void* _sin(void* tensor) {
     g_bytes_used += t.bytes();
     return new fl::Tensor(t);
   } catch (std::exception const& e) {
-    HANDLE_EXCEPTION(e, "_sin");
+    HANDLE_EXCEPTION(e);
   }
 }
 
@@ -223,7 +223,7 @@ void* _cos(void* tensor) {
     g_bytes_used += t.bytes();
     return new fl::Tensor(t);
   } catch (std::exception const& e) {
-    HANDLE_EXCEPTION(e, "_cos");
+    HANDLE_EXCEPTION(e);
   }
 }
 
@@ -236,7 +236,7 @@ void* _sqrt(void* tensor) {
     g_bytes_used += t.bytes();
     return new fl::Tensor(t);
   } catch (std::exception const& e) {
-    HANDLE_EXCEPTION(e, "_sqrt");
+    HANDLE_EXCEPTION(e);
   }
 }
 
@@ -249,7 +249,7 @@ void* _tanh(void* tensor) {
     g_bytes_used += t.bytes();
     return new fl::Tensor(t);
   } catch (std::exception const& e) {
-    HANDLE_EXCEPTION(e, "_tanh");
+    HANDLE_EXCEPTION(e);
   }
 }
 
@@ -262,7 +262,7 @@ void* _floor(void* tensor) {
     g_bytes_used += t.bytes();
     return new fl::Tensor(t);
   } catch (std::exception const& e) {
-    HANDLE_EXCEPTION(e, "_floor");
+    HANDLE_EXCEPTION(e);
   }
 }
 
@@ -275,7 +275,7 @@ void* _ceil(void* tensor) {
     g_bytes_used += t.bytes();
     return new fl::Tensor(t);
   } catch (std::exception const& e) {
-    HANDLE_EXCEPTION(e, "_ceil");
+    HANDLE_EXCEPTION(e);
   }
 }
 
@@ -288,7 +288,7 @@ void* _rint(void* tensor) {
     g_bytes_used += t.bytes();
     return new fl::Tensor(t);
   } catch (std::exception const& e) {
-    HANDLE_EXCEPTION(e, "_rint");
+    HANDLE_EXCEPTION(e);
   }
 }
 
@@ -301,7 +301,7 @@ void* _absolute(void* tensor) {
     g_bytes_used += t.bytes();
     return new fl::Tensor(t);
   } catch (std::exception const& e) {
-    HANDLE_EXCEPTION(e, "_absolute");
+    HANDLE_EXCEPTION(e);
   }
 }
 
@@ -314,7 +314,7 @@ void* _sigmoid(void* tensor) {
     g_bytes_used += t.bytes();
     return new fl::Tensor(t);
   } catch (std::exception const& e) {
-    HANDLE_EXCEPTION(e, "_sigmoid");
+    HANDLE_EXCEPTION(e);
   }
 }
 
@@ -327,7 +327,7 @@ void* _erf(void* tensor) {
     g_bytes_used += t.bytes();
     return new fl::Tensor(t);
   } catch (std::exception const& e) {
-    HANDLE_EXCEPTION(e, "_erf");
+    HANDLE_EXCEPTION(e);
   }
 }
 
@@ -340,7 +340,7 @@ void* _flip(void* tensor, uint32_t dim) {
     g_bytes_used += t.bytes();
     return new fl::Tensor(t);
   } catch (std::exception const& e) {
-    HANDLE_EXCEPTION(e, "_flip");
+    HANDLE_EXCEPTION(e);
   }
 }
 
@@ -355,7 +355,7 @@ void* _clip(void* tensor, void* low, void* high) {
     g_bytes_used += t.bytes();
     return new fl::Tensor(t);
   } catch (std::exception const& e) {
-    HANDLE_EXCEPTION(e, "_clip");
+    HANDLE_EXCEPTION(e);
   }
 }
 
@@ -369,7 +369,7 @@ void* _roll(void* tensor, int shift, int32_t axis) {
     g_bytes_used += t.bytes();
     return new fl::Tensor(t);
   } catch (std::exception const& e) {
-    HANDLE_EXCEPTION(e, "_roll");
+    HANDLE_EXCEPTION(e);
   }
 }
 
@@ -382,7 +382,7 @@ void* _isnan(void* tensor) {
     g_bytes_used += t.bytes();
     return new fl::Tensor(t);
   } catch (std::exception const& e) {
-    HANDLE_EXCEPTION(e, "_isnan");
+    HANDLE_EXCEPTION(e);
   }
 }
 
@@ -395,7 +395,7 @@ void* _isinf(void* tensor) {
     g_bytes_used += t.bytes();
     return new fl::Tensor(t);
   } catch (std::exception const& e) {
-    HANDLE_EXCEPTION(e, "_isinf");
+    HANDLE_EXCEPTION(e);
   }
 }
 
@@ -408,7 +408,7 @@ void* _sign(void* tensor) {
     g_bytes_used += t.bytes();
     return new fl::Tensor(t);
   } catch (std::exception const& e) {
-    HANDLE_EXCEPTION(e, "_sign");
+    HANDLE_EXCEPTION(e);
   }
 }
 
@@ -421,7 +421,7 @@ void* _tril(void* tensor) {
     g_bytes_used += t.bytes();
     return new fl::Tensor(t);
   } catch (std::exception const& e) {
-    HANDLE_EXCEPTION(e, "_tril");
+    HANDLE_EXCEPTION(e);
   }
 }
 
@@ -434,7 +434,7 @@ void* _triu(void* tensor) {
     g_bytes_used += t.bytes();
     return new fl::Tensor(t);
   } catch (std::exception const& e) {
-    HANDLE_EXCEPTION(e, "_triu");
+    HANDLE_EXCEPTION(e);
   }
 }
 
@@ -449,7 +449,7 @@ void* _where(void* cond, void* x, void* y) {
     g_bytes_used += t.bytes();
     return new fl::Tensor(t);
   } catch (std::exception const& e) {
-    HANDLE_EXCEPTION(e, "_where");
+    HANDLE_EXCEPTION(e);
   }
 }
 
@@ -462,7 +462,7 @@ void* _sort(void* tensor, uint32_t dim) {
     g_bytes_used += t.bytes();
     return new fl::Tensor(t);
   } catch (std::exception const& e) {
-    HANDLE_EXCEPTION(e, "_sort");
+    HANDLE_EXCEPTION(e);
   }
 }
 
@@ -476,7 +476,7 @@ void* _add(void* tensor, void* other) {
     g_bytes_used += t.bytes();
     return new fl::Tensor(t);
   } catch (std::exception const& e) {
-    HANDLE_EXCEPTION(e, "_add");
+    HANDLE_EXCEPTION(e);
   }
 }
 
@@ -490,7 +490,7 @@ void* _sub(void* tensor, void* other) {
     g_bytes_used += t.bytes();
     return new fl::Tensor(t);
   } catch (std::exception const& e) {
-    HANDLE_EXCEPTION(e, "_sub");
+    HANDLE_EXCEPTION(e);
   }
 }
 
@@ -504,7 +504,7 @@ void* _mul(void* tensor, void* other) {
     g_bytes_used += t.bytes();
     return new fl::Tensor(t);
   } catch (std::exception const& e) {
-    HANDLE_EXCEPTION(e, "_mul");
+    HANDLE_EXCEPTION(e);
   }
 }
 
@@ -518,7 +518,7 @@ void* _div(void* tensor, void* other) {
     g_bytes_used += t.bytes();
     return new fl::Tensor(t);
   } catch (std::exception const& e) {
-    HANDLE_EXCEPTION(e, "_div");
+    HANDLE_EXCEPTION(e);
   }
 }
 
@@ -532,7 +532,7 @@ void* _eq(void* tensor, void* other) {
     g_bytes_used += t.bytes();
     return new fl::Tensor(t);
   } catch (std::exception const& e) {
-    HANDLE_EXCEPTION(e, "_eq");
+    HANDLE_EXCEPTION(e);
   }
 }
 
@@ -546,7 +546,7 @@ void* _neq(void* tensor, void* other) {
     g_bytes_used += t.bytes();
     return new fl::Tensor(t);
   } catch (std::exception const& e) {
-    HANDLE_EXCEPTION(e, "_neq");
+    HANDLE_EXCEPTION(e);
   }
 }
 
@@ -560,7 +560,7 @@ void* _lessThan(void* tensor, void* other) {
     g_bytes_used += t.bytes();
     return new fl::Tensor(t);
   } catch (std::exception const& e) {
-    HANDLE_EXCEPTION(e, "_lessThan");
+    HANDLE_EXCEPTION(e);
   }
 }
 
@@ -574,7 +574,7 @@ void* _lessThanEqual(void* tensor, void* other) {
     g_bytes_used += t.bytes();
     return new fl::Tensor(t);
   } catch (std::exception const& e) {
-    HANDLE_EXCEPTION(e, "_lessThanEqual");
+    HANDLE_EXCEPTION(e);
   }
 }
 
@@ -588,7 +588,7 @@ void* _greaterThan(void* tensor, void* other) {
     g_bytes_used += t.bytes();
     return new fl::Tensor(t);
   } catch (std::exception const& e) {
-    HANDLE_EXCEPTION(e, "_greaterThan");
+    HANDLE_EXCEPTION(e);
   }
 }
 
@@ -602,7 +602,7 @@ void* _greaterThanEqual(void* tensor, void* other) {
     g_bytes_used += t.bytes();
     return new fl::Tensor(t);
   } catch (std::exception const& e) {
-    HANDLE_EXCEPTION(e, "_greaterThanEqual");
+    HANDLE_EXCEPTION(e);
   }
 }
 
@@ -616,7 +616,7 @@ void* _logicalOr(void* tensor, void* other) {
     g_bytes_used += t.bytes();
     return new fl::Tensor(t);
   } catch (std::exception const& e) {
-    HANDLE_EXCEPTION(e, "_logicalOr");
+    HANDLE_EXCEPTION(e);
   }
 }
 
@@ -630,7 +630,7 @@ void* _logicalAnd(void* tensor, void* other) {
     g_bytes_used += t.bytes();
     return new fl::Tensor(t);
   } catch (std::exception const& e) {
-    HANDLE_EXCEPTION(e, "_logicalAnd");
+    HANDLE_EXCEPTION(e);
   }
 }
 
@@ -644,7 +644,7 @@ void* _mod(void* tensor, void* other) {
     g_bytes_used += t.bytes();
     return new fl::Tensor(t);
   } catch (std::exception const& e) {
-    HANDLE_EXCEPTION(e, "_mod");
+    HANDLE_EXCEPTION(e);
   }
 }
 
@@ -658,7 +658,7 @@ void* _bitwiseAnd(void* tensor, void* other) {
     g_bytes_used += t.bytes();
     return new fl::Tensor(t);
   } catch (std::exception const& e) {
-    HANDLE_EXCEPTION(e, "_bitwiseAnd");
+    HANDLE_EXCEPTION(e);
   }
 }
 
@@ -672,7 +672,7 @@ void* _bitwiseOr(void* tensor, void* other) {
     g_bytes_used += t.bytes();
     return new fl::Tensor(t);
   } catch (std::exception const& e) {
-    HANDLE_EXCEPTION(e, "_bitwiseOr");
+    HANDLE_EXCEPTION(e);
   }
 }
 
@@ -686,7 +686,7 @@ void* _bitwiseXor(void* tensor, void* other) {
     g_bytes_used += t.bytes();
     return new fl::Tensor(t);
   } catch (std::exception const& e) {
-    HANDLE_EXCEPTION(e, "_bitwiseXor");
+    HANDLE_EXCEPTION(e);
   }
 }
 
@@ -700,7 +700,7 @@ void* _lShift(void* tensor, void* other) {
     g_bytes_used += t.bytes();
     return new fl::Tensor(t);
   } catch (std::exception const& e) {
-    HANDLE_EXCEPTION(e, "_lShift");
+    HANDLE_EXCEPTION(e);
   }
 }
 
@@ -714,7 +714,7 @@ void* _rShift(void* tensor, void* other) {
     g_bytes_used += t.bytes();
     return new fl::Tensor(t);
   } catch (std::exception const& e) {
-    HANDLE_EXCEPTION(e, "_rShift");
+    HANDLE_EXCEPTION(e);
   }
 }
 
@@ -728,7 +728,7 @@ void* _minimum(void* tensor, void* other) {
     g_bytes_used += t.bytes();
     return new fl::Tensor(t);
   } catch (std::exception const& e) {
-    HANDLE_EXCEPTION(e, "_minimum");
+    HANDLE_EXCEPTION(e);
   }
 }
 
@@ -742,7 +742,7 @@ void* _maximum(void* tensor, void* other) {
     g_bytes_used += t.bytes();
     return new fl::Tensor(t);
   } catch (std::exception const& e) {
-    HANDLE_EXCEPTION(e, "_maximum");
+    HANDLE_EXCEPTION(e);
   }
 }
 
@@ -756,7 +756,7 @@ void* _power(void* tensor, void* other) {
     g_bytes_used += t.bytes();
     return new fl::Tensor(t);
   } catch (std::exception const& e) {
-    HANDLE_EXCEPTION(e, "_power");
+    HANDLE_EXCEPTION(e);
   }
 }
 
@@ -776,7 +776,7 @@ void* _matmul(void* tensor, void* other) {
       return new fl::Tensor(t);
     }
   } catch (std::exception const& e) {
-    HANDLE_EXCEPTION(e, "_matmul");
+    HANDLE_EXCEPTION(e);
   }
 }
 
@@ -799,7 +799,7 @@ void* _conv2d(void* tensor,
     g_bytes_used += t.bytes();
     return new fl::Tensor(t);
   } catch (std::exception const& e) {
-    HANDLE_EXCEPTION(e, "_conv2d");
+    HANDLE_EXCEPTION(e);
   }
 }
 
@@ -831,7 +831,7 @@ void* _amin(void* tensor, void* axes_ptr, int64_t axes_len, bool keep_dims) {
     g_bytes_used += t.bytes();
     return new fl::Tensor(t);
   } catch (std::exception const& e) {
-    HANDLE_EXCEPTION(e, "_amin");
+    HANDLE_EXCEPTION(e);
   }
 }
 
@@ -863,7 +863,7 @@ void* _amax(void* tensor, void* axes_ptr, int64_t axes_len, bool keep_dims) {
     g_bytes_used += t.bytes();
     return new fl::Tensor(t);
   } catch (std::exception const& e) {
-    HANDLE_EXCEPTION(e, "_amax");
+    HANDLE_EXCEPTION(e);
   }
 }
 
@@ -893,7 +893,7 @@ void* _argmin(void* tensor, int32_t axis, bool keep_dims) {
     g_bytes_used += t.bytes();
     return new fl::Tensor(t);
   } catch (std::exception const& e) {
-    HANDLE_EXCEPTION(e, "_argmin");
+    HANDLE_EXCEPTION(e);
   }
 }
 
@@ -923,7 +923,7 @@ void* _argmax(void* tensor, int32_t axis, bool keep_dims) {
     g_bytes_used += t.bytes();
     return new fl::Tensor(t);
   } catch (std::exception const& e) {
-    HANDLE_EXCEPTION(e, "_argmax");
+    HANDLE_EXCEPTION(e);
   }
 }
 
@@ -955,7 +955,7 @@ void* _sum(void* tensor, void* axes_ptr, int64_t axes_len, bool keep_dims) {
     g_bytes_used += t.bytes();
     return new fl::Tensor(t);
   } catch (std::exception const& e) {
-    HANDLE_EXCEPTION(e, "_sum");
+    HANDLE_EXCEPTION(e);
   }
 }
 
@@ -969,7 +969,7 @@ void* _cumsum(void* tensor, int32_t axis) {
     g_bytes_used += t.bytes();
     return new fl::Tensor(t);
   } catch (std::exception const& e) {
-    HANDLE_EXCEPTION(e, "_cumsum");
+    HANDLE_EXCEPTION(e);
   }
 }
 
@@ -1001,7 +1001,7 @@ void* _mean(void* tensor, void* axes_ptr, int64_t axes_len, bool keep_dims) {
     g_bytes_used += t.bytes();
     return new fl::Tensor(t);
   } catch (std::exception const& e) {
-    HANDLE_EXCEPTION(e, "_mean");
+    HANDLE_EXCEPTION(e);
   }
 }
 
@@ -1033,7 +1033,7 @@ void* _median(void* tensor, void* axes_ptr, int64_t axes_len, bool keep_dims) {
     g_bytes_used += t.bytes();
     return new fl::Tensor(t);
   } catch (std::exception const& e) {
-    HANDLE_EXCEPTION(e, "_median");
+    HANDLE_EXCEPTION(e);
   }
 }
 
@@ -1069,7 +1069,7 @@ void* _var(void* tensor,
     g_bytes_used += t.bytes();
     return new fl::Tensor(t);
   } catch (std::exception const& e) {
-    HANDLE_EXCEPTION(e, "_var");
+    HANDLE_EXCEPTION(e);
   }
 }
 
@@ -1101,7 +1101,7 @@ void* _std(void* tensor, void* axes_ptr, int64_t axes_len, bool keep_dims) {
     g_bytes_used += t.bytes();
     return new fl::Tensor(t);
   } catch (std::exception const& e) {
-    HANDLE_EXCEPTION(e, "_std");
+    HANDLE_EXCEPTION(e);
   }
 }
 
@@ -1142,7 +1142,7 @@ void* _norm(void* tensor,
     g_bytes_used += t.bytes();
     return new fl::Tensor(t);
   } catch (std::exception const& e) {
-    HANDLE_EXCEPTION(e, "_norm");
+    HANDLE_EXCEPTION(e);
   }
 }
 
@@ -1177,7 +1177,7 @@ void* _countNonzero(void* tensor,
     g_bytes_used += t.bytes();
     return new fl::Tensor(t);
   } catch (std::exception const& e) {
-    HANDLE_EXCEPTION(e, "_countNonzero");
+    HANDLE_EXCEPTION(e);
   }
 }
 
@@ -1209,7 +1209,7 @@ void* _any(void* tensor, void* axes_ptr, int64_t axes_len, bool keep_dims) {
     g_bytes_used += t.bytes();
     return new fl::Tensor(t);
   } catch (std::exception const& e) {
-    HANDLE_EXCEPTION(e, "_any");
+    HANDLE_EXCEPTION(e);
   }
 }
 
@@ -1241,6 +1241,6 @@ void* _all(void* tensor, void* axes_ptr, int64_t axes_len, bool keep_dims) {
     g_bytes_used += t.bytes();
     return new fl::Tensor(t);
   } catch (std::exception const& e) {
-    HANDLE_EXCEPTION(e, "_all");
+    HANDLE_EXCEPTION(e);
   }
 }

--- a/shumai/cpp/flashlight_binding.cc
+++ b/shumai/cpp/flashlight_binding.cc
@@ -23,15 +23,15 @@
 #define FMT_BOLD_WHITE "\033[1m\033[97m"
 #define FMT_BOLD_ITALIC_WHITE "\033[1m\033[3m\033[97m"
 
-#define HANDLE_EXCEPTION(e)                                                \
-  {                                                                        \
-    std::cerr << FMT_RED << "native code error" << FMT_GRAY << ": "        \
-              << FMT_BOLD_WHITE << e.what() << FMT_RESET << FMT_GRAY       \
-              << "\n                  at " << FMT_BOLD_ITALIC_WHITE        \
-              << __FUNCTION__ << FMT_RESET << FMT_GRAY << " (" << FMT_CYAN \
-              << __FILE__ << FMT_GRAY << ":" << FMT_YELLOW << __LINE__     \
-              << FMT_GRAY << ")" << FMT_RESET << std::endl;                \
-    return nullptr;                                                        \
+#define HANDLE_EXCEPTION(e)                                            \
+  {                                                                    \
+    std::cerr << FMT_RED << "native code error" << FMT_GRAY << ": "    \
+              << FMT_BOLD_WHITE << e.what() << FMT_RESET << FMT_GRAY   \
+              << "\n                  at " << FMT_BOLD_ITALIC_WHITE    \
+              << __func__ << FMT_RESET << FMT_GRAY << " (" << FMT_CYAN \
+              << __FILE__ << FMT_GRAY << ":" << FMT_YELLOW << __LINE__ \
+              << FMT_GRAY << ")" << FMT_RESET << std::endl;            \
+    return nullptr;                                                    \
   }
 
 #if 0

--- a/shumai/cpp/flashlight_binding.cc
+++ b/shumai/cpp/flashlight_binding.cc
@@ -23,15 +23,15 @@
 #define FMT_BOLD_WHITE "\033[1m\033[97m"
 #define FMT_BOLD_ITALIC_WHITE "\033[1m\033[3m\033[97m"
 
-#define HANDLE_EXCEPTION(e, op_name)                                           \
-  {                                                                            \
-    std::cerr << FMT_RED << "native code error" << FMT_GRAY << ": "            \
-              << FMT_BOLD_WHITE << e.what() << FMT_RESET << FMT_GRAY           \
-              << "\n                  at " << FMT_BOLD_ITALIC_WHITE << op_name \
-              << FMT_RESET << FMT_GRAY << " (" << FMT_CYAN << __FILE__         \
-              << FMT_GRAY << ":" << FMT_YELLOW << __LINE__ << FMT_GRAY << ")"  \
-              << FMT_RESET << std::endl;                                       \
-    return nullptr;                                                            \
+#define HANDLE_EXCEPTION(e)                                                \
+  {                                                                        \
+    std::cerr << FMT_RED << "native code error" << FMT_GRAY << ": "        \
+              << FMT_BOLD_WHITE << e.what() << FMT_RESET << FMT_GRAY       \
+              << "\n                  at " << FMT_BOLD_ITALIC_WHITE        \
+              << __FUNCTION__ << FMT_RESET << FMT_GRAY << " (" << FMT_CYAN \
+              << __FILE__ << FMT_GRAY << ":" << FMT_YELLOW << __LINE__     \
+              << FMT_GRAY << ")" << FMT_RESET << std::endl;                \
+    return nullptr;                                                        \
   }
 
 #if 0
@@ -91,7 +91,7 @@ void* createTensor(void* shape_ptr, int64_t shape_len) {
     g_bytes_used += t->bytes();
     return t;
   } catch (std::exception const& e) {
-    HANDLE_EXCEPTION(e, "createTensor");
+    HANDLE_EXCEPTION(e);
   }
 }
 
@@ -103,7 +103,7 @@ void* tensorFromFloat32Buffer(int64_t numel, void* ptr) {
     g_bytes_used += t->bytes();
     return t;
   } catch (std::exception const& e) {
-    HANDLE_EXCEPTION(e, "tensorFromFloat32Buffer");
+    HANDLE_EXCEPTION(e);
   }
 }
 
@@ -115,7 +115,7 @@ void* tensorFromFloat64Buffer(int64_t numel, void* ptr) {
     g_bytes_used += t->bytes();
     return t;
   } catch (std::exception const& e) {
-    HANDLE_EXCEPTION(e, "tensorFromFloat64Buffer");
+    HANDLE_EXCEPTION(e);
   }
 }
 
@@ -127,7 +127,7 @@ void* tensorFromInt8Buffer(int64_t numel, void* ptr) {
     g_bytes_used += t->bytes();
     return t;
   } catch (std::exception const& e) {
-    HANDLE_EXCEPTION(e, "tensorFromInt8Buffer");
+    HANDLE_EXCEPTION(e);
   }
 }
 
@@ -139,7 +139,7 @@ void* tensorFromInt16Buffer(int64_t numel, void* ptr) {
     g_bytes_used += t->bytes();
     return t;
   } catch (std::exception const& e) {
-    HANDLE_EXCEPTION(e, "tensorFromInt16Buffer");
+    HANDLE_EXCEPTION(e);
   }
 }
 
@@ -151,7 +151,7 @@ void* tensorFromInt32Buffer(int64_t numel, void* ptr) {
     g_bytes_used += t->bytes();
     return t;
   } catch (std::exception const& e) {
-    HANDLE_EXCEPTION(e, "tensorFromInt32Buffer");
+    HANDLE_EXCEPTION(e);
   }
 }
 
@@ -163,7 +163,7 @@ void* tensorFromInt64Buffer(int64_t numel, void* ptr) {
     g_bytes_used += t->bytes();
     return t;
   } catch (std::exception const& e) {
-    HANDLE_EXCEPTION(e, "tensorFromInt64Buffer");
+    HANDLE_EXCEPTION(e);
   }
 }
 
@@ -175,7 +175,7 @@ void* tensorFromUint8Buffer(int64_t numel, void* ptr) {
     g_bytes_used += t->bytes();
     return t;
   } catch (std::exception const& e) {
-    HANDLE_EXCEPTION(e, "tensorFromUint8Buffer");
+    HANDLE_EXCEPTION(e);
   }
 }
 
@@ -187,7 +187,7 @@ void* tensorFromUint16Buffer(int64_t numel, void* ptr) {
     g_bytes_used += t->bytes();
     return t;
   } catch (std::exception const& e) {
-    HANDLE_EXCEPTION(e, "tensorFromUint16Buffer");
+    HANDLE_EXCEPTION(e);
   }
 }
 
@@ -199,7 +199,7 @@ void* tensorFromUint32Buffer(int64_t numel, void* ptr) {
     g_bytes_used += t->bytes();
     return t;
   } catch (std::exception const& e) {
-    HANDLE_EXCEPTION(e, "tensorFromUint32Buffer");
+    HANDLE_EXCEPTION(e);
   }
 }
 
@@ -211,7 +211,7 @@ void* tensorFromUint64Buffer(int64_t numel, void* ptr) {
     g_bytes_used += t->bytes();
     return t;
   } catch (std::exception const& e) {
-    HANDLE_EXCEPTION(e, "tensorFromUint64Buffer");
+    HANDLE_EXCEPTION(e);
   }
 }
 
@@ -262,7 +262,7 @@ void* load(char* cstr) {
     g_bytes_used += t->bytes();
     return t;
   } catch (std::exception const& e) {
-    HANDLE_EXCEPTION(e, "load");
+    HANDLE_EXCEPTION(e);
   }
 }
 
@@ -312,7 +312,7 @@ void* _astype(void* t, int type) {
     g_bytes_used += new_tensor.bytes();
     return new fl::Tensor(new_tensor);
   } catch (std::exception const& e) {
-    HANDLE_EXCEPTION(e, "_astype");
+    HANDLE_EXCEPTION(e);
   }
 }
 
@@ -382,7 +382,7 @@ float* _float16Buffer(void* t) {
     auto* tensor = reinterpret_cast<fl::Tensor*>(t);
     return tensor->astype(fl::dtype::f16).host<float>();
   } catch (std::exception const& e) {
-    HANDLE_EXCEPTION(e, "_float16Buffer");
+    HANDLE_EXCEPTION(e);
   }
 }
 
@@ -392,7 +392,7 @@ float* _float32Buffer(void* t) {
     auto* tensor = reinterpret_cast<fl::Tensor*>(t);
     return tensor->astype(fl::dtype::f32).host<float>();
   } catch (std::exception const& e) {
-    HANDLE_EXCEPTION(e, "_float32Buffer");
+    HANDLE_EXCEPTION(e);
   }
 }
 
@@ -402,7 +402,7 @@ float* _float64Buffer(void* t) {
     auto* tensor = reinterpret_cast<fl::Tensor*>(t);
     return tensor->astype(fl::dtype::f64).host<float>();
   } catch (std::exception const& e) {
-    HANDLE_EXCEPTION(e, "_float64Buffer");
+    HANDLE_EXCEPTION(e);
   }
 }
 
@@ -412,7 +412,7 @@ int* _int16Buffer(void* t) {
     auto* tensor = reinterpret_cast<fl::Tensor*>(t);
     return tensor->astype(fl::dtype::s16).host<int>();
   } catch (std::exception const& e) {
-    HANDLE_EXCEPTION(e, "_int16Buffer");
+    HANDLE_EXCEPTION(e);
   }
 }
 
@@ -422,7 +422,7 @@ int* _int32Buffer(void* t) {
     auto* tensor = reinterpret_cast<fl::Tensor*>(t);
     return tensor->astype(fl::dtype::s32).host<int>();
   } catch (std::exception const& e) {
-    HANDLE_EXCEPTION(e, "_int32Buffer");
+    HANDLE_EXCEPTION(e);
   }
 }
 
@@ -432,7 +432,7 @@ int* _int64Buffer(void* t) {
     auto* tensor = reinterpret_cast<fl::Tensor*>(t);
     return tensor->astype(fl::dtype::s64).host<int>();
   } catch (std::exception const& e) {
-    HANDLE_EXCEPTION(e, "_int64Buffer");
+    HANDLE_EXCEPTION(e);
   }
 }
 
@@ -442,7 +442,7 @@ unsigned* _uint8Buffer(void* t) {
     auto* tensor = reinterpret_cast<fl::Tensor*>(t);
     return tensor->astype(fl::dtype::u8).host<unsigned>();
   } catch (std::exception const& e) {
-    HANDLE_EXCEPTION(e, "_uint8Buffer");
+    HANDLE_EXCEPTION(e);
   }
 }
 
@@ -452,7 +452,7 @@ unsigned* _uint16Buffer(void* t) {
     auto* tensor = reinterpret_cast<fl::Tensor*>(t);
     return tensor->astype(fl::dtype::u16).host<unsigned>();
   } catch (std::exception const& e) {
-    HANDLE_EXCEPTION(e, "_uint16Buffer");
+    HANDLE_EXCEPTION(e);
   }
 }
 
@@ -462,7 +462,7 @@ unsigned* _uint32Buffer(void* t) {
     auto* tensor = reinterpret_cast<fl::Tensor*>(t);
     return tensor->astype(fl::dtype::u32).host<unsigned>();
   } catch (std::exception const& e) {
-    HANDLE_EXCEPTION(e, "_uint32Buffer");
+    HANDLE_EXCEPTION(e);
   }
 }
 
@@ -472,7 +472,7 @@ unsigned* _uint64Buffer(void* t) {
     auto* tensor = reinterpret_cast<fl::Tensor*>(t);
     return tensor->astype(fl::dtype::u64).host<unsigned>();
   } catch (std::exception const& e) {
-    HANDLE_EXCEPTION(e, "_uint64Buffer");
+    HANDLE_EXCEPTION(e);
   }
 }
 
@@ -511,7 +511,7 @@ void* _index(void* t,
     g_bytes_used += new_tensor->bytes();
     return new_tensor;
   } catch (std::exception const& e) {
-    HANDLE_EXCEPTION(e, "_index");
+    HANDLE_EXCEPTION(e);
   }
 }
 
@@ -549,7 +549,7 @@ void* _indexedAssign(void* t,
     g_bytes_used += new_tensor->bytes();
     return new_tensor;
   } catch (std::exception const& e) {
-    HANDLE_EXCEPTION(e, "_indexedAssign");
+    HANDLE_EXCEPTION(e);
   }
 }
 
@@ -561,7 +561,7 @@ void* _flatten(void* t) {
     g_bytes_used += new_tensor->bytes();
     return new_tensor;
   } catch (std::exception const& e) {
-    HANDLE_EXCEPTION(e, "_flatten");
+    HANDLE_EXCEPTION(e);
   }
 }
 
@@ -573,7 +573,7 @@ void* _asContiguousTensor(void* t) {
     g_bytes_used += new_tensor->bytes();
     return new_tensor;
   } catch (std::exception const& e) {
-    HANDLE_EXCEPTION(e, "_asContiguousTensor");
+    HANDLE_EXCEPTION(e);
   }
 }
 
@@ -585,7 +585,7 @@ void* _copy(void* t) {
     g_bytes_used += new_tensor->bytes();
     return new_tensor;
   } catch (std::exception const& e) {
-    HANDLE_EXCEPTION(e, "_copy");
+    HANDLE_EXCEPTION(e);
   }
 }
 
@@ -608,7 +608,7 @@ void* _pad(void* t,
     g_bytes_used += new_tensor->bytes();
     return new_tensor;
   } catch (std::exception const& e) {
-    HANDLE_EXCEPTION(e, "_pad");
+    HANDLE_EXCEPTION(e);
   }
 }
 
@@ -642,7 +642,7 @@ void* _conv2dBackwardData(void* grad_in,
     g_bytes_used += result.bytes();
     return new fl::Tensor(result);
   } catch (std::exception const& e) {
-    HANDLE_EXCEPTION(e, "_conv2dBackwardData");
+    HANDLE_EXCEPTION(e);
   }
 }
 

--- a/shumai/cpp/flashlight_binding.cc
+++ b/shumai/cpp/flashlight_binding.cc
@@ -83,92 +83,136 @@ size_t bytesUsed() {
 }
 
 void* createTensor(void* shape_ptr, int64_t shape_len) {
-  LOCK_GUARD
-  static_assert(sizeof(long long) == sizeof(int64_t));
-  auto shape = arrayArg<long long>(shape_ptr, shape_len, g_row_major, false);
-  auto* t = new fl::Tensor(fl::Shape(shape));
-  g_bytes_used += t->bytes();
-  return t;
+  try {
+    LOCK_GUARD
+    static_assert(sizeof(long long) == sizeof(int64_t));
+    auto shape = arrayArg<long long>(shape_ptr, shape_len, g_row_major, false);
+    auto* t = new fl::Tensor(fl::Shape(shape));
+    g_bytes_used += t->bytes();
+    return t;
+  } catch (std::exception const& e) {
+    HANDLE_EXCEPTION(e, "createTensor");
+  }
 }
 
 void* tensorFromFloat32Buffer(int64_t numel, void* ptr) {
-  LOCK_GUARD
-  auto* t = new fl::Tensor(
-      fl::Tensor::fromBuffer({numel}, (float*)ptr, fl::MemoryLocation::Host));
-  g_bytes_used += t->bytes();
-  return t;
+  try {
+    LOCK_GUARD
+    auto* t = new fl::Tensor(
+        fl::Tensor::fromBuffer({numel}, (float*)ptr, fl::MemoryLocation::Host));
+    g_bytes_used += t->bytes();
+    return t;
+  } catch (std::exception const& e) {
+    HANDLE_EXCEPTION(e, "tensorFromFloat32Buffer");
+  }
 }
 
 void* tensorFromFloat64Buffer(int64_t numel, void* ptr) {
-  LOCK_GUARD
-  auto* t = new fl::Tensor(
-      fl::Tensor::fromBuffer({numel}, (double*)ptr, fl::MemoryLocation::Host));
-  g_bytes_used += t->bytes();
-  return t;
+  try {
+    LOCK_GUARD
+    auto* t = new fl::Tensor(fl::Tensor::fromBuffer({numel}, (double*)ptr,
+                                                    fl::MemoryLocation::Host));
+    g_bytes_used += t->bytes();
+    return t;
+  } catch (std::exception const& e) {
+    HANDLE_EXCEPTION(e, "tensorFromFloat64Buffer");
+  }
 }
 
 void* tensorFromInt8Buffer(int64_t numel, void* ptr) {
-  LOCK_GUARD
-  auto* t = new fl::Tensor(
-      fl::Tensor::fromBuffer({numel}, (char*)ptr, fl::MemoryLocation::Host));
-  g_bytes_used += t->bytes();
-  return t;
+  try {
+    LOCK_GUARD
+    auto* t = new fl::Tensor(
+        fl::Tensor::fromBuffer({numel}, (char*)ptr, fl::MemoryLocation::Host));
+    g_bytes_used += t->bytes();
+    return t;
+  } catch (std::exception const& e) {
+    HANDLE_EXCEPTION(e, "tensorFromInt8Buffer");
+  }
 }
 
 void* tensorFromInt16Buffer(int64_t numel, void* ptr) {
-  LOCK_GUARD
-  auto* t = new fl::Tensor(
-      fl::Tensor::fromBuffer({numel}, (int16_t*)ptr, fl::MemoryLocation::Host));
-  g_bytes_used += t->bytes();
-  return t;
+  try {
+    LOCK_GUARD
+    auto* t = new fl::Tensor(fl::Tensor::fromBuffer({numel}, (int16_t*)ptr,
+                                                    fl::MemoryLocation::Host));
+    g_bytes_used += t->bytes();
+    return t;
+  } catch (std::exception const& e) {
+    HANDLE_EXCEPTION(e, "tensorFromInt16Buffer");
+  }
 }
 
 void* tensorFromInt32Buffer(int64_t numel, void* ptr) {
-  LOCK_GUARD
-  auto* t = new fl::Tensor(
-      fl::Tensor::fromBuffer({numel}, (int32_t*)ptr, fl::MemoryLocation::Host));
-  g_bytes_used += t->bytes();
-  return t;
+  try {
+    LOCK_GUARD
+    auto* t = new fl::Tensor(fl::Tensor::fromBuffer({numel}, (int32_t*)ptr,
+                                                    fl::MemoryLocation::Host));
+    g_bytes_used += t->bytes();
+    return t;
+  } catch (std::exception const& e) {
+    HANDLE_EXCEPTION(e, "tensorFromInt32Buffer");
+  }
 }
 
 void* tensorFromInt64Buffer(int64_t numel, void* ptr) {
-  LOCK_GUARD
-  auto* t = new fl::Tensor(
-      fl::Tensor::fromBuffer({numel}, (int64_t*)ptr, fl::MemoryLocation::Host));
-  g_bytes_used += t->bytes();
-  return t;
+  try {
+    LOCK_GUARD
+    auto* t = new fl::Tensor(fl::Tensor::fromBuffer({numel}, (int64_t*)ptr,
+                                                    fl::MemoryLocation::Host));
+    g_bytes_used += t->bytes();
+    return t;
+  } catch (std::exception const& e) {
+    HANDLE_EXCEPTION(e, "tensorFromInt64Buffer");
+  }
 }
 
 void* tensorFromUint8Buffer(int64_t numel, void* ptr) {
-  LOCK_GUARD
-  auto* t = new fl::Tensor(
-      fl::Tensor::fromBuffer({numel}, (uint8_t*)ptr, fl::MemoryLocation::Host));
-  g_bytes_used += t->bytes();
-  return t;
+  try {
+    LOCK_GUARD
+    auto* t = new fl::Tensor(fl::Tensor::fromBuffer({numel}, (uint8_t*)ptr,
+                                                    fl::MemoryLocation::Host));
+    g_bytes_used += t->bytes();
+    return t;
+  } catch (std::exception const& e) {
+    HANDLE_EXCEPTION(e, "tensorFromUint8Buffer");
+  }
 }
 
 void* tensorFromUint16Buffer(int64_t numel, void* ptr) {
-  LOCK_GUARD
-  auto* t = new fl::Tensor(fl::Tensor::fromBuffer({numel}, (uint16_t*)ptr,
-                                                  fl::MemoryLocation::Host));
-  g_bytes_used += t->bytes();
-  return t;
+  try {
+    LOCK_GUARD
+    auto* t = new fl::Tensor(fl::Tensor::fromBuffer({numel}, (uint16_t*)ptr,
+                                                    fl::MemoryLocation::Host));
+    g_bytes_used += t->bytes();
+    return t;
+  } catch (std::exception const& e) {
+    HANDLE_EXCEPTION(e, "tensorFromUint16Buffer");
+  }
 }
 
 void* tensorFromUint32Buffer(int64_t numel, void* ptr) {
-  LOCK_GUARD
-  auto* t = new fl::Tensor(fl::Tensor::fromBuffer({numel}, (uint32_t*)ptr,
-                                                  fl::MemoryLocation::Host));
-  g_bytes_used += t->bytes();
-  return t;
+  try {
+    LOCK_GUARD
+    auto* t = new fl::Tensor(fl::Tensor::fromBuffer({numel}, (uint32_t*)ptr,
+                                                    fl::MemoryLocation::Host));
+    g_bytes_used += t->bytes();
+    return t;
+  } catch (std::exception const& e) {
+    HANDLE_EXCEPTION(e, "tensorFromUint32Buffer");
+  }
 }
 
 void* tensorFromUint64Buffer(int64_t numel, void* ptr) {
-  LOCK_GUARD
-  auto* t = new fl::Tensor(fl::Tensor::fromBuffer({numel}, (uint64_t*)ptr,
-                                                  fl::MemoryLocation::Host));
-  g_bytes_used += t->bytes();
-  return t;
+  try {
+    LOCK_GUARD
+    auto* t = new fl::Tensor(fl::Tensor::fromBuffer({numel}, (uint64_t*)ptr,
+                                                    fl::MemoryLocation::Host));
+    g_bytes_used += t->bytes();
+    return t;
+  } catch (std::exception const& e) {
+    HANDLE_EXCEPTION(e, "tensorFromUint64Buffer");
+  }
 }
 
 void destroyTensor(void* t, void* /*ignore*/) {
@@ -209,13 +253,17 @@ void _save(void* t, char* cstr) {
 }
 
 void* load(char* cstr) {
-  LOCK_GUARD
-  auto filename = std::string(cstr);
-  fl::Tensor tensor;
-  fl::load(filename, tensor);
-  auto* t = new fl::Tensor(tensor);
-  g_bytes_used += t->bytes();
-  return t;
+  try {
+    LOCK_GUARD
+    auto filename = std::string(cstr);
+    fl::Tensor tensor;
+    fl::load(filename, tensor);
+    auto* t = new fl::Tensor(tensor);
+    g_bytes_used += t->bytes();
+    return t;
+  } catch (std::exception const& e) {
+    HANDLE_EXCEPTION(e, "load");
+  }
 }
 
 void _eval(void* t) {
@@ -256,12 +304,16 @@ int _ndim(void* t) {
 }
 
 void* _astype(void* t, int type) {
-  LOCK_GUARD
-  auto dtype = static_cast<fl::dtype>(type);
-  auto* tensor = reinterpret_cast<fl::Tensor*>(t);
-  auto new_tensor = tensor->astype(dtype);
-  g_bytes_used += new_tensor.bytes();
-  return new fl::Tensor(new_tensor);
+  try {
+    LOCK_GUARD
+    auto dtype = static_cast<fl::dtype>(type);
+    auto* tensor = reinterpret_cast<fl::Tensor*>(t);
+    auto new_tensor = tensor->astype(dtype);
+    g_bytes_used += new_tensor.bytes();
+    return new fl::Tensor(new_tensor);
+  } catch (std::exception const& e) {
+    HANDLE_EXCEPTION(e, "_astype");
+  }
 }
 
 int _dtype(void* t) {
@@ -325,63 +377,103 @@ int dtypeUint64() {
 }
 
 float* _float16Buffer(void* t) {
-  LOCK_GUARD
-  auto* tensor = reinterpret_cast<fl::Tensor*>(t);
-  return tensor->astype(fl::dtype::f16).host<float>();
+  try {
+    LOCK_GUARD
+    auto* tensor = reinterpret_cast<fl::Tensor*>(t);
+    return tensor->astype(fl::dtype::f16).host<float>();
+  } catch (std::exception const& e) {
+    HANDLE_EXCEPTION(e, "_float16Buffer");
+  }
 }
 
 float* _float32Buffer(void* t) {
-  LOCK_GUARD
-  auto* tensor = reinterpret_cast<fl::Tensor*>(t);
-  return tensor->astype(fl::dtype::f32).host<float>();
+  try {
+    LOCK_GUARD
+    auto* tensor = reinterpret_cast<fl::Tensor*>(t);
+    return tensor->astype(fl::dtype::f32).host<float>();
+  } catch (std::exception const& e) {
+    HANDLE_EXCEPTION(e, "_float32Buffer");
+  }
 }
 
 float* _float64Buffer(void* t) {
-  LOCK_GUARD
-  auto* tensor = reinterpret_cast<fl::Tensor*>(t);
-  return tensor->astype(fl::dtype::f64).host<float>();
+  try {
+    LOCK_GUARD
+    auto* tensor = reinterpret_cast<fl::Tensor*>(t);
+    return tensor->astype(fl::dtype::f64).host<float>();
+  } catch (std::exception const& e) {
+    HANDLE_EXCEPTION(e, "_float64Buffer");
+  }
 }
 
 int* _int16Buffer(void* t) {
-  LOCK_GUARD
-  auto* tensor = reinterpret_cast<fl::Tensor*>(t);
-  return tensor->astype(fl::dtype::s16).host<int>();
+  try {
+    LOCK_GUARD
+    auto* tensor = reinterpret_cast<fl::Tensor*>(t);
+    return tensor->astype(fl::dtype::s16).host<int>();
+  } catch (std::exception const& e) {
+    HANDLE_EXCEPTION(e, "_int16Buffer");
+  }
 }
 
 int* _int32Buffer(void* t) {
-  LOCK_GUARD
-  auto* tensor = reinterpret_cast<fl::Tensor*>(t);
-  return tensor->astype(fl::dtype::s32).host<int>();
+  try {
+    LOCK_GUARD
+    auto* tensor = reinterpret_cast<fl::Tensor*>(t);
+    return tensor->astype(fl::dtype::s32).host<int>();
+  } catch (std::exception const& e) {
+    HANDLE_EXCEPTION(e, "_int32Buffer");
+  }
 }
 
 int* _int64Buffer(void* t) {
-  LOCK_GUARD
-  auto* tensor = reinterpret_cast<fl::Tensor*>(t);
-  return tensor->astype(fl::dtype::s64).host<int>();
+  try {
+    LOCK_GUARD
+    auto* tensor = reinterpret_cast<fl::Tensor*>(t);
+    return tensor->astype(fl::dtype::s64).host<int>();
+  } catch (std::exception const& e) {
+    HANDLE_EXCEPTION(e, "_int64Buffer");
+  }
 }
 
 unsigned* _uint8Buffer(void* t) {
-  LOCK_GUARD
-  auto* tensor = reinterpret_cast<fl::Tensor*>(t);
-  return tensor->astype(fl::dtype::u8).host<unsigned>();
+  try {
+    LOCK_GUARD
+    auto* tensor = reinterpret_cast<fl::Tensor*>(t);
+    return tensor->astype(fl::dtype::u8).host<unsigned>();
+  } catch (std::exception const& e) {
+    HANDLE_EXCEPTION(e, "_uint8Buffer");
+  }
 }
 
 unsigned* _uint16Buffer(void* t) {
-  LOCK_GUARD
-  auto* tensor = reinterpret_cast<fl::Tensor*>(t);
-  return tensor->astype(fl::dtype::u16).host<unsigned>();
+  try {
+    LOCK_GUARD
+    auto* tensor = reinterpret_cast<fl::Tensor*>(t);
+    return tensor->astype(fl::dtype::u16).host<unsigned>();
+  } catch (std::exception const& e) {
+    HANDLE_EXCEPTION(e, "_uint16Buffer");
+  }
 }
 
 unsigned* _uint32Buffer(void* t) {
-  LOCK_GUARD
-  auto* tensor = reinterpret_cast<fl::Tensor*>(t);
-  return tensor->astype(fl::dtype::u32).host<unsigned>();
+  try {
+    LOCK_GUARD
+    auto* tensor = reinterpret_cast<fl::Tensor*>(t);
+    return tensor->astype(fl::dtype::u32).host<unsigned>();
+  } catch (std::exception const& e) {
+    HANDLE_EXCEPTION(e, "_uint32Buffer");
+  }
 }
 
 unsigned* _uint64Buffer(void* t) {
-  LOCK_GUARD
-  auto* tensor = reinterpret_cast<fl::Tensor*>(t);
-  return tensor->astype(fl::dtype::u64).host<unsigned>();
+  try {
+    LOCK_GUARD
+    auto* tensor = reinterpret_cast<fl::Tensor*>(t);
+    return tensor->astype(fl::dtype::u64).host<unsigned>();
+  } catch (std::exception const& e) {
+    HANDLE_EXCEPTION(e, "_uint64Buffer");
+  }
 }
 
 float _scalar(void* t) {
@@ -397,26 +489,30 @@ void* _index(void* t,
              int64_t ends_len,
              void* strides,
              int64_t strides_len) {
-  LOCK_GUARD
-  auto start = arrayArg<int64_t>(starts, starts_len, g_row_major, false);
-  auto end = arrayArg<int64_t>(ends, ends_len, g_row_major, false);
-  auto stride = arrayArg<int64_t>(strides, strides_len, g_row_major, false);
-  std::vector<fl::Index> indices;
-  indices.reserve(start.size());
-  for (auto i = 0; i < start.size(); ++i) {
-    if (start[i] == -1 && end[i] == -1) {
-      indices.emplace_back(fl::span);
-    } else if (start[i] + 1 == end[i]) {
-      indices.emplace_back(start[i]);
-    } else {
-      indices.emplace_back(
-          fl::range(start[i], end[i], strides_len ? stride[i] : 1));
+  try {
+    LOCK_GUARD
+    auto start = arrayArg<int64_t>(starts, starts_len, g_row_major, false);
+    auto end = arrayArg<int64_t>(ends, ends_len, g_row_major, false);
+    auto stride = arrayArg<int64_t>(strides, strides_len, g_row_major, false);
+    std::vector<fl::Index> indices;
+    indices.reserve(start.size());
+    for (auto i = 0; i < start.size(); ++i) {
+      if (start[i] == -1 && end[i] == -1) {
+        indices.emplace_back(fl::span);
+      } else if (start[i] + 1 == end[i]) {
+        indices.emplace_back(start[i]);
+      } else {
+        indices.emplace_back(
+            fl::range(start[i], end[i], strides_len ? stride[i] : 1));
+      }
     }
+    auto* tensor = reinterpret_cast<fl::Tensor*>(t);
+    auto* new_tensor = new fl::Tensor(tensor->operator()(indices));
+    g_bytes_used += new_tensor->bytes();
+    return new_tensor;
+  } catch (std::exception const& e) {
+    HANDLE_EXCEPTION(e, "_index");
   }
-  auto* tensor = reinterpret_cast<fl::Tensor*>(t);
-  auto* new_tensor = new fl::Tensor(tensor->operator()(indices));
-  g_bytes_used += new_tensor->bytes();
-  return new_tensor;
 }
 
 void* _indexedAssign(void* t,
@@ -427,54 +523,70 @@ void* _indexedAssign(void* t,
                      int64_t ends_len,
                      void* strides,
                      int64_t strides_len) {
-  LOCK_GUARD
-  auto start = arrayArg<int64_t>(starts, starts_len, g_row_major, false);
-  auto end = arrayArg<int64_t>(ends, ends_len, g_row_major, false);
-  auto stride = arrayArg<int64_t>(strides, strides_len, g_row_major, false);
-  std::vector<fl::Index> indices;
-  indices.reserve(start.size());
-  for (auto i = 0; i < start.size(); ++i) {
-    if (start[i] == -1 && end[i] == -1) {
-      indices.emplace_back(fl::span);
-    } else if (start[i] + 1 == end[i]) {
-      indices.emplace_back(start[i]);
-    } else {
-      indices.emplace_back(
-          fl::range(start[i], end[i], strides_len ? stride[i] : 1));
+  try {
+    LOCK_GUARD
+    auto start = arrayArg<int64_t>(starts, starts_len, g_row_major, false);
+    auto end = arrayArg<int64_t>(ends, ends_len, g_row_major, false);
+    auto stride = arrayArg<int64_t>(strides, strides_len, g_row_major, false);
+    std::vector<fl::Index> indices;
+    indices.reserve(start.size());
+    for (auto i = 0; i < start.size(); ++i) {
+      if (start[i] == -1 && end[i] == -1) {
+        indices.emplace_back(fl::span);
+      } else if (start[i] + 1 == end[i]) {
+        indices.emplace_back(start[i]);
+      } else {
+        indices.emplace_back(
+            fl::range(start[i], end[i], strides_len ? stride[i] : 1));
+      }
     }
+    auto* tensor = reinterpret_cast<fl::Tensor*>(t);
+    auto new_t = tensor->copy();
+    auto* assign = reinterpret_cast<fl::Tensor*>(other);
+    new_t(indices) *= 0;
+    new_t(indices) += *assign;
+    auto* new_tensor = new fl::Tensor(new_t);
+    g_bytes_used += new_tensor->bytes();
+    return new_tensor;
+  } catch (std::exception const& e) {
+    HANDLE_EXCEPTION(e, "_indexedAssign");
   }
-  auto* tensor = reinterpret_cast<fl::Tensor*>(t);
-  auto new_t = tensor->copy();
-  auto* assign = reinterpret_cast<fl::Tensor*>(other);
-  new_t(indices) *= 0;
-  new_t(indices) += *assign;
-  auto* new_tensor = new fl::Tensor(new_t);
-  g_bytes_used += new_tensor->bytes();
-  return new_tensor;
 }
 
 void* _flatten(void* t) {
-  LOCK_GUARD
-  auto* tensor = reinterpret_cast<fl::Tensor*>(t);
-  auto* new_tensor = new fl::Tensor(tensor->flatten());
-  g_bytes_used += new_tensor->bytes();
-  return new_tensor;
+  try {
+    LOCK_GUARD
+    auto* tensor = reinterpret_cast<fl::Tensor*>(t);
+    auto* new_tensor = new fl::Tensor(tensor->flatten());
+    g_bytes_used += new_tensor->bytes();
+    return new_tensor;
+  } catch (std::exception const& e) {
+    HANDLE_EXCEPTION(e, "_flatten");
+  }
 }
 
 void* _asContiguousTensor(void* t) {
-  LOCK_GUARD
-  auto* tensor = reinterpret_cast<fl::Tensor*>(t);
-  auto* new_tensor = new fl::Tensor(tensor->asContiguousTensor());
-  g_bytes_used += new_tensor->bytes();
-  return new_tensor;
+  try {
+    LOCK_GUARD
+    auto* tensor = reinterpret_cast<fl::Tensor*>(t);
+    auto* new_tensor = new fl::Tensor(tensor->asContiguousTensor());
+    g_bytes_used += new_tensor->bytes();
+    return new_tensor;
+  } catch (std::exception const& e) {
+    HANDLE_EXCEPTION(e, "_asContiguousTensor");
+  }
 }
 
 void* _copy(void* t) {
-  LOCK_GUARD
-  auto* tensor = reinterpret_cast<fl::Tensor*>(t);
-  auto* new_tensor = new fl::Tensor(tensor->copy());
-  g_bytes_used += new_tensor->bytes();
-  return new_tensor;
+  try {
+    LOCK_GUARD
+    auto* tensor = reinterpret_cast<fl::Tensor*>(t);
+    auto* new_tensor = new fl::Tensor(tensor->copy());
+    g_bytes_used += new_tensor->bytes();
+    return new_tensor;
+  } catch (std::exception const& e) {
+    HANDLE_EXCEPTION(e, "_copy");
+  }
 }
 
 void* _pad(void* t,
@@ -482,18 +594,22 @@ void* _pad(void* t,
            int64_t before_len,
            void* after,
            int64_t after_len) {
-  LOCK_GUARD
-  auto* tensor = reinterpret_cast<fl::Tensor*>(t);
-  auto before_vec = arrayArg<int64_t>(before, before_len, g_row_major, false);
-  auto after_vec = arrayArg<int64_t>(after, after_len, g_row_major, false);
-  std::vector<std::pair<int, int>> pair_vec;
-  pair_vec.reserve(after_vec.size());
-  for (auto i = 0; i < after_vec.size(); ++i) {
-    pair_vec.emplace_back(before_vec[i], after_vec[i]);
+  try {
+    LOCK_GUARD
+    auto* tensor = reinterpret_cast<fl::Tensor*>(t);
+    auto before_vec = arrayArg<int64_t>(before, before_len, g_row_major, false);
+    auto after_vec = arrayArg<int64_t>(after, after_len, g_row_major, false);
+    std::vector<std::pair<int, int>> pair_vec;
+    pair_vec.reserve(after_vec.size());
+    for (auto i = 0; i < after_vec.size(); ++i) {
+      pair_vec.emplace_back(before_vec[i], after_vec[i]);
+    }
+    auto* new_tensor = new fl::Tensor(fl::pad(*tensor, pair_vec));
+    g_bytes_used += new_tensor->bytes();
+    return new_tensor;
+  } catch (std::exception const& e) {
+    HANDLE_EXCEPTION(e, "_pad");
   }
-  auto* new_tensor = new fl::Tensor(fl::pad(*tensor, pair_vec));
-  g_bytes_used += new_tensor->bytes();
-  return new_tensor;
 }
 
 // `grad_in` is Shumai equivalent to Flashlight `gradOutput`


### PR DESCRIPTION
Wrap all remaining native functions that return a pointer in a Try/Catch and call `HANDLE_EXCEPTION` accordingly.