### PR TITLE
Optimize SGD

### DIFF
--- a/shumai/optim/sgd.ts
+++ b/shumai/optim/sgd.ts
@@ -5,8 +5,8 @@ export function sgd(
   learning_rate = 1e-3
 ) {
   const lr = sm.scalar(-learning_rate)
-  for (const k of Object.keys(grads)) {
-    const { tensor: t, grad: g } = grads[k]
+  for (const [k,v] of Object.entries(grads)) {
+    const { tensor: t, grad: g } = v
     if (t.requires_grad) {
       t.update(t.detach().add(g.detach().mul(lr)))
     }


### PR DESCRIPTION
Most use cases won't see any perf benefits, but in general we should always avoid having to do hash lookups when all we're doing is processing all entries.