### PR TITLE
Clarify usage of gradients before/after optimizer

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -55,11 +55,13 @@ const loss = sm.loss.mse(X, W)
 
 // backward returns a list of differentiated tensors
 const ts = loss.backward()
+
+// gradients are accessible from the original tensors
+// gradients are NOT available after optimizer
+const delta = W.grad.mul(sm.scalar(-1e-2))
+
 // we can optimize these tensors in place!
 sm.optim.sgd(ts, 1e-2)
-
-// gradients are also accessible from the original tensors
-const delta = W.grad.mul(sm.scalar(-1e2))
 
 // use `detach` to copy W without tracking gradients
 const Y = W.detach()


### PR DESCRIPTION
In part made this PR to make sure the intention of the optimizer was to wipe out the gradients. I get why it was done, but I could argue `backward` could have been responsible for the reset. The way it is now is likely most performant since unreferenced gradients can be freed.