### PR TITLE
Implemented TensorVector bindings and `sm.concatenate`

### DIFF
--- a/scripts/gen_binding.py
+++ b/scripts/gen_binding.py
@@ -62,7 +62,7 @@ op_list = [
     ("reshape", [("Tensor", "tensor"), "Shape"], "Tensor"),
     ("transpose", [("Tensor", "tensor"), ("Shape", "axes")], "Tensor"),
     ("tile", [("Tensor", "tensor"), "Shape"], "Tensor"),
-    # ("concatenate", ["TensorVector", ("int32_t", "axis")], "Tensor"),
+    ("concatenate", ["TensorVector", ("int32_t", "axis")], "Tensor"),
     ("nonzero", [("Tensor", "tensor")], "Tensor"),
     # ("pad", [("Tensor", "tensor"), "PairVector"], "Tensor"),
     ("negative", ["Tensor"], "Tensor"),

--- a/scripts/gen_binding.py
+++ b/scripts/gen_binding.py
@@ -346,7 +346,7 @@ for op, args, ret in op_list:
             if op == "concatenate":
                 # Strange behaviour in Flashlight where concatenating scalars with negative axis fails to expand, unlike with non-scalar tensors
                 js_impl.append(f"if (axis < 0) {{ for (let i = 0; i < {n}.length; ++i) {{ if ({n}[i].shape.length === 0) {{ {n}[i] = {n}[i].reshape([1]) }} }} }}")
-            js_impl.append(f"const [{n}_ptr, {n}_len] = arrayArg({n}, FFIType.i64);")
+            js_impl.append(f"const [{n}_ptr, {n}_len] = arrayArg({n});")
             js_args.append(f"{n}_ptr")
             js_args.append(f"{n}_len")
             js_arg_types.append(f"TensorVector_ptr")
@@ -368,7 +368,7 @@ for op, args, ret in op_list:
             c_op_args.append(f"fl::Shape({n})")
             ffi_sig.append("FFIType.ptr")
             ffi_sig.append("FFIType.i64")
-            js_impl.append(f"const [{n}_ptr, {n}_len] = arrayArg({n}, FFIType.i64);")
+            js_impl.append(f"const [{n}_ptr, {n}_len] = arrayArg({n});")
             js_args.append(f"{n}_ptr")
             js_args.append(f"{n}_len")
             js_arg_types.append("Shape_ptr")
@@ -385,7 +385,7 @@ for op, args, ret in op_list:
             c_op_args.append(f"{n}")
             ffi_sig.append("FFIType.ptr")
             ffi_sig.append("FFIType.i64")
-            js_impl.append(f"const [{n}_ptr, {n}_len] = arrayArg({n}, FFIType.i64);")
+            js_impl.append(f"const [{n}_ptr, {n}_len] = arrayArg({n});")
             js_args.append(f"{n}_ptr")
             js_args.append(f"{n}_len")
             js_arg_types.append("Axes_ptr")

--- a/scripts/gen_binding.py
+++ b/scripts/gen_binding.py
@@ -485,10 +485,10 @@ for op, args, ret in op_list:
         js_tensor_args = ["this"] + js_tensor_args
     js_ptr_args = [x[0] if x[1] != "Tensor" else f"{x[0]}.ptr" for x in wrap_args]
     js_ptr_result = f"const _ptr = fl._{op}({', '.join(js_ptr_args)})"
-    js_provenance_args = '||'.join([f"{t}.provenance" for t in js_tensor_args] + [f"{tv}.some((t) => t.provenance)" for tv in js_tensor_vector_args])
-    js_requires_grad_args = '||'.join([f"{t}.requires_grad" for t in js_tensor_args] + [f"{tv}.some((t) => t.requires_grad)" for tv in js_tensor_vector_args])
+    js_provenance_args = '||'.join([f"{t}.provenance" for t in js_tensor_args] + [f"{tv}.reduce((r, c) => r || c.provenance, 0)" for tv in js_tensor_vector_args])
+    js_requires_grad_args = '||'.join([f"{t}.requires_grad" for t in js_tensor_args] + [f"{tv}.reduce((r, c) => r || c.requires_grad, false)" for tv in js_tensor_vector_args])
     js_requires_grad_args = 'false' if len(js_requires_grad_args) == 0 else js_requires_grad_args
-    js_requires_stats = '||'.join([f"{t}.requires_stats" for t in js_tensor_args] + [f"{tv}.some((t) => t.requires_stats)" for tv in js_tensor_vector_args])
+    js_requires_stats = '||'.join([f"{t}.requires_stats" for t in js_tensor_args] + [f"{tv}.reduce((r, c) => r || c.requires_stats, false)" for tv in js_tensor_vector_args])
     js_requires_stats = 'false' if len(js_requires_stats) == 0 else js_requires_stats
     js_grad_args = (['this'] if methods_only else []) + [f"...{n}" if t == "TensorVector" else f"{n}" for n, t in zip(js_grad_args, js_grad_arg_types)]
     js_deps = f"const deps = requires_grad ? [{', '.join(js_grad_args)}] : []"

--- a/scripts/gen_binding.py
+++ b/scripts/gen_binding.py
@@ -336,6 +336,9 @@ for op, args, ret in op_list:
             c_op_args.append(f"{n}")
             ffi_sig.append("FFIType.ptr")
             ffi_sig.append("FFIType.i64")
+            if op == "concatenate":
+                # Strange behaviour in Flashlight where concatenating scalars with negative axis fails to expand, unlike with non-scalar tensors
+                js_impl.append(f"if (axis < 0) {{ for (let i = 0; i < {n}.length; ++i) {{ if ({n}[i].shape.length === 0) {{ {n}[i] = {n}[i].reshape([1]) }} }} }}")
             js_impl.append(f"const [{n}_ptr, {n}_len] = arrayArg({n}, FFIType.i64);")
             js_args.append(f"{n}_ptr")
             js_args.append(f"{n}_len")

--- a/shumai/cpp/binding_gen.inl
+++ b/shumai/cpp/binding_gen.inl
@@ -123,6 +123,20 @@ void* _tile(void* tensor, void* shape_ptr, int64_t shape_len) {
   }
 }
 
+void* _concatenate(void* tensors_ptr, int64_t tensors_len, int32_t axis) {
+  try {
+    LOCK_GUARD
+
+    auto tensors = ptrArrayArg<fl::Tensor>(tensors_ptr, tensors_len);
+    auto used_axis = axisArg(axis, g_row_major, (&tensors[0])->ndim());
+    auto t = fl::concatenate(tensors, used_axis);
+    g_bytes_used += t.bytes();
+    return new fl::Tensor(t);
+  } catch (std::exception const& e) {
+    HANDLE_EXCEPTION(e);
+  }
+}
+
 void* _nonzero(void* tensor) {
   try {
     LOCK_GUARD

--- a/shumai/cpp/flashlight_binding.cc
+++ b/shumai/cpp/flashlight_binding.cc
@@ -46,18 +46,30 @@ static std::atomic<size_t> g_bytes_used = 0;
 static std::atomic<bool> g_row_major = true;
 
 template <typename T>
-std::vector<T> arrayArg(void* ptr, int len, bool reverse, int invert) {
+std::vector<T> arrayArg(const void* ptr, int len, bool reverse, int invert) {
   std::vector<T> out;
   out.reserve(len);
   for (auto i = 0; i < len; ++i) {
     const auto idx = reverse ? len - i - 1 : i;
-    auto v = reinterpret_cast<int64_t*>(ptr)[idx];
+    auto v = reinterpret_cast<const int64_t*>(ptr)[idx];
     if (invert && v < 0) {
       v = -v - 1;
     } else if (invert) {
       v = invert - v - 1;
     }
     out.emplace_back(v);
+  }
+  return out;
+}
+
+template <typename T>
+std::vector<T> ptrArrayArg(const void* ptr, int len) {
+  std::vector<T> out;
+  out.reserve(len);
+  for (auto i = 0; i < len; ++i) {
+    auto ptrAsInt = reinterpret_cast<const int64_t*>(ptr)[i];
+    auto ptr = reinterpret_cast<T*>(ptrAsInt);
+    out.emplace_back(*ptr);
   }
   return out;
 }

--- a/shumai/ffi/ffi_bind_utils.ts
+++ b/shumai/ffi/ffi_bind_utils.ts
@@ -1,16 +1,17 @@
 import { ptr, FFIType } from 'bun:ffi'
 import { Tensor } from '@shumai/shumai'
 
-function arrayArg(arg: number | number[] | BigInt64Array | Array<Tensor>, type: FFIType) {
+function arrayArg(arg: number | number[] | Tensor[] | BigInt64Array) {
   if (typeof arg === 'number') arg = [arg]
 
   if (arg.length == 0) {
     return [0, 0]
   }
 
-  let numArray: number[] | BigInt64Array
+  let outArray: BigInt64Array
+
   if (arg instanceof Array) {
-    numArray = []
+    const numArray: number[] = []
     for (let i = 0; i < arg.length; ++i) {
       const item = arg[i]
       if (typeof item === 'number') {
@@ -21,20 +22,9 @@ function arrayArg(arg: number | number[] | BigInt64Array | Array<Tensor>, type: 
         throw new Error(`Unsupported type at position ${i} of input arg`)
       }
     }
+    outArray = new BigInt64Array(numArray.map((x) => BigInt(x)))
   } else {
-    numArray = arg
-  }
-
-  let outArray: Int32Array | BigInt64Array
-  switch (type) {
-    case FFIType.i32:
-      outArray = new Int32Array(numArray)
-      break
-    case FFIType.i64:
-      outArray = new BigInt64Array(numArray.map((x) => BigInt(x)))
-      break
-    default:
-      throw new Error(`Unsupported type: ${type}`)
+    outArray = arg
   }
 
   return [ptr(outArray), outArray.length]

--- a/shumai/ffi/ffi_bind_utils.ts
+++ b/shumai/ffi/ffi_bind_utils.ts
@@ -1,25 +1,43 @@
 import { ptr, FFIType } from 'bun:ffi'
+import { Tensor } from '@shumai/shumai'
 
-function arrayArg(arg: number | number[] | BigInt64Array, type: FFIType) {
+function arrayArg(arg: number | number[] | BigInt64Array | Array<Tensor>, type: FFIType) {
   if (typeof arg === 'number') arg = [arg]
 
   if (arg.length == 0) {
     return [0, 0]
   }
 
-  let array: Int32Array | BigInt64Array
+  let numArray: number[] | BigInt64Array
+  if (arg instanceof Array) {
+    numArray = []
+    for (let i = 0; i < arg.length; ++i) {
+      const item = arg[i]
+      if (typeof item === 'number') {
+        numArray.push(item)
+      } else if (item instanceof Tensor) {
+        numArray.push(item.ptr)
+      } else {
+        throw new Error(`Unsupported type at position ${i} of input arg`)
+      }
+    }
+  } else {
+    numArray = arg
+  }
+
+  let outArray: Int32Array | BigInt64Array
   switch (type) {
     case FFIType.i32:
-      array = new Int32Array(arg)
+      outArray = new Int32Array(numArray)
       break
     case FFIType.i64:
-      array = new BigInt64Array(arg.map((x) => BigInt(x)))
+      outArray = new BigInt64Array(numArray.map((x) => BigInt(x)))
       break
     default:
       throw new Error(`Unsupported type: ${type}`)
   }
 
-  return [ptr(array), array.length]
+  return [ptr(outArray), outArray.length]
 }
 
 export { arrayArg }

--- a/shumai/ffi/ffi_tensor_ops_gen.ts
+++ b/shumai/ffi/ffi_tensor_ops_gen.ts
@@ -37,6 +37,10 @@ const ffi_tensor_ops = {
     args: [FFIType.ptr, FFIType.ptr, FFIType.i64],
     returns: FFIType.ptr
   },
+  _concatenate: {
+    args: [FFIType.ptr, FFIType.i64, FFIType.i32],
+    returns: FFIType.ptr
+  },
   _nonzero: {
     args: [FFIType.ptr],
     returns: FFIType.ptr

--- a/shumai/optim/sgd.ts
+++ b/shumai/optim/sgd.ts
@@ -5,7 +5,7 @@ export function sgd(
   learning_rate = 1e-3
 ) {
   const lr = sm.scalar(-learning_rate)
-  for (const [k,v] of Object.entries(grads)) {
+  for (const [k, v] of Object.entries(grads)) {
     const { tensor: t, grad: g } = v
     if (t.requires_grad) {
       t.update(t.detach().add(g.detach().mul(lr)))

--- a/shumai/tensor/tensor.ts
+++ b/shumai/tensor/tensor.ts
@@ -540,9 +540,28 @@ export class Tensor {
     const end = []
     const stride = []
     for (const arg of args) {
-      if (arg == ':') {
-        start.push(-1)
-        end.push(-1)
+      if (typeof arg === 'string') {
+        const tokens = arg.split(':').map((x, i) => x.trim())
+        let start_idx = -1
+        let end_idx = -1
+        if (tokens.length >= 1) {
+          if (tokens[0] !== '' || tokens.length === 1) {
+            start_idx = parseInt(tokens[0]) // When length === 1, '' is parsed to NaN
+            end_idx = start_idx + 1
+          }
+        }
+        if (tokens.length >= 2) {
+          if (tokens[1] === '') {
+            end_idx = -1
+          } else {
+            end_idx = parseInt(tokens[1])
+          }
+        }
+        if (tokens.length >= 3 || start_idx === NaN || end_idx === NaN) {
+          throw `${arg} not yet supported.  Please file a bug with desired behavior!`
+        }
+        start.push(start_idx)
+        end.push(end_idx)
       } else if (typeof arg === 'number') {
         start.push(arg)
         end.push(arg + 1)

--- a/shumai/tensor/tensor.ts
+++ b/shumai/tensor/tensor.ts
@@ -432,7 +432,7 @@ export class Tensor {
     return wrapFLTensor(fl._copy.native, this.ptr)
   }
 
-  pad(paddings) {
+  pad(paddings: Array<Array<number>>) {
     const before_ = paddings.map((x) => {
       return BigInt(x[0])
     })
@@ -442,8 +442,8 @@ export class Tensor {
     return wrapFLTensor(
       fl._pad.native,
       this.ptr,
-      ...arrayArg(before_, FFIType.i64),
-      ...arrayArg(after_, FFIType.i64)
+      ...arrayArg(new BigInt64Array(before_), FFIType.i64),
+      ...arrayArg(new BigInt64Array(after_), FFIType.i64)
     )
   }
 

--- a/shumai/tensor/tensor_ops_gen.ts
+++ b/shumai/tensor/tensor_ops_gen.ts
@@ -22,7 +22,7 @@ import { Tensor } from './tensor'
  *
  *   @returns A new {@link Tensor} of uniformly random values
  */ export function rand(shape: BigInt64Array | number[]) {
-  const [shape_ptr, shape_len] = arrayArg(shape, FFIType.i64)
+  const [shape_ptr, shape_len] = arrayArg(shape)
   const requires_stats = false
 
   let stats = null
@@ -80,7 +80,7 @@ import { Tensor } from './tensor'
  *
  *   @returns A new {@link Tensor} of random values sampled from a Gaussian distribution
  */ export function randn(shape: BigInt64Array | number[]) {
-  const [shape_ptr, shape_len] = arrayArg(shape, FFIType.i64)
+  const [shape_ptr, shape_len] = arrayArg(shape)
   const requires_stats = false
 
   let stats = null
@@ -136,7 +136,7 @@ import { Tensor } from './tensor'
  *
  *   @returns A new {@link Tensor} of a single user specified value.
  */ export function full(shape: BigInt64Array | number[], val: number) {
-  const [shape_ptr, shape_len] = arrayArg(shape, FFIType.i64)
+  const [shape_ptr, shape_len] = arrayArg(shape)
   const requires_stats = false
 
   let stats = null
@@ -313,8 +313,8 @@ export function eye(dim: number) {
  *   @param tileDims - How to tile the intermediate tensor.
  *   @returns A new {@link Tensor}
  */ export function iota(dims: BigInt64Array | number[], tileDims: BigInt64Array | number[] = [1]) {
-  const [dims_ptr, dims_len] = arrayArg(dims, FFIType.i64)
-  const [tileDims_ptr, tileDims_len] = arrayArg(tileDims, FFIType.i64)
+  const [dims_ptr, dims_len] = arrayArg(dims)
+  const [tileDims_ptr, tileDims_len] = arrayArg(tileDims)
   const requires_stats = false
 
   let stats = null
@@ -376,7 +376,7 @@ export function eye(dim: number) {
  *   @param tensor - {@link Tensor} to reshape
  *   @param shape - The shape of the output {@link Tensor}
  */ export function reshape(tensor: Tensor, shape: BigInt64Array | number[]) {
-  const [shape_ptr, shape_len] = arrayArg(shape, FFIType.i64)
+  const [shape_ptr, shape_len] = arrayArg(shape)
   const requires_stats = tensor.requires_stats
 
   let stats = null
@@ -440,7 +440,7 @@ export function eye(dim: number) {
  *   @param axes - The new order of the indices of the current axes after tranposing
  *   @returns A new {@link Tensor}
  */ export function transpose(tensor: Tensor, axes: BigInt64Array | number[]) {
-  const [axes_ptr, axes_len] = arrayArg(axes, FFIType.i64)
+  const [axes_ptr, axes_len] = arrayArg(axes)
   const requires_stats = tensor.requires_stats
 
   let stats = null
@@ -507,7 +507,7 @@ export function eye(dim: number) {
  *   @param shape - A shape describing the number of iterations to tile each axis.
  *   @returns A new {@link Tensor}
  */ export function tile(tensor: Tensor, shape: BigInt64Array | number[]) {
-  const [shape_ptr, shape_len] = arrayArg(shape, FFIType.i64)
+  const [shape_ptr, shape_len] = arrayArg(shape)
   const requires_stats = tensor.requires_stats
 
   let stats = null
@@ -557,7 +557,7 @@ export function concatenate(tensors: Array<Tensor>, axis: number) {
       }
     }
   }
-  const [tensors_ptr, tensors_len] = arrayArg(tensors, FFIType.i64)
+  const [tensors_ptr, tensors_len] = arrayArg(tensors)
   const requires_stats = tensors.some((t) => t.requires_stats)
 
   let stats = null
@@ -3029,7 +3029,7 @@ export function conv2d(
 }
 
 export function amin(tensor: Tensor, axes: BigInt64Array | number[] = [], keep_dims = false) {
-  const [axes_ptr, axes_len] = arrayArg(axes, FFIType.i64)
+  const [axes_ptr, axes_len] = arrayArg(axes)
   const requires_stats = tensor.requires_stats
 
   let stats = null
@@ -3072,7 +3072,7 @@ export function amin(tensor: Tensor, axes: BigInt64Array | number[] = [], keep_d
 }
 
 export function amax(tensor: Tensor, axes: BigInt64Array | number[] = [], keep_dims = false) {
-  const [axes_ptr, axes_len] = arrayArg(axes, FFIType.i64)
+  const [axes_ptr, axes_len] = arrayArg(axes)
   const requires_stats = tensor.requires_stats
 
   let stats = null
@@ -3199,7 +3199,7 @@ export function argmax(tensor: Tensor, axis: number, keep_dims = false) {
 }
 
 export function sum(tensor: Tensor, axes: BigInt64Array | number[] = [], keep_dims = false) {
-  const [axes_ptr, axes_len] = arrayArg(axes, FFIType.i64)
+  const [axes_ptr, axes_len] = arrayArg(axes)
   const requires_stats = tensor.requires_stats
 
   let stats = null
@@ -3284,7 +3284,7 @@ export function cumsum(tensor: Tensor, axis: number) {
 }
 
 export function mean(tensor: Tensor, axes: BigInt64Array | number[] = [], keep_dims = false) {
-  const [axes_ptr, axes_len] = arrayArg(axes, FFIType.i64)
+  const [axes_ptr, axes_len] = arrayArg(axes)
   const requires_stats = tensor.requires_stats
 
   let stats = null
@@ -3327,7 +3327,7 @@ export function mean(tensor: Tensor, axes: BigInt64Array | number[] = [], keep_d
 }
 
 export function median(tensor: Tensor, axes: BigInt64Array | number[] = [], keep_dims = false) {
-  const [axes_ptr, axes_len] = arrayArg(axes, FFIType.i64)
+  const [axes_ptr, axes_len] = arrayArg(axes)
   const requires_stats = tensor.requires_stats
 
   let stats = null
@@ -3375,7 +3375,7 @@ export function _var(
   bias = false,
   keep_dims = false
 ) {
-  const [axes_ptr, axes_len] = arrayArg(axes, FFIType.i64)
+  const [axes_ptr, axes_len] = arrayArg(axes)
   const requires_stats = tensor.requires_stats
 
   let stats = null
@@ -3427,7 +3427,7 @@ export function variance(
 }
 
 export function std(tensor: Tensor, axes: BigInt64Array | number[] = [], keep_dims = false) {
-  const [axes_ptr, axes_len] = arrayArg(axes, FFIType.i64)
+  const [axes_ptr, axes_len] = arrayArg(axes)
   const requires_stats = tensor.requires_stats
 
   let stats = null
@@ -3475,7 +3475,7 @@ export function norm(
   p = 2,
   keep_dims = false
 ) {
-  const [axes_ptr, axes_len] = arrayArg(axes, FFIType.i64)
+  const [axes_ptr, axes_len] = arrayArg(axes)
   const requires_stats = tensor.requires_stats
 
   let stats = null
@@ -3539,7 +3539,7 @@ export function countNonzero(
   axes: BigInt64Array | number[] = [],
   keep_dims = false
 ) {
-  const [axes_ptr, axes_len] = arrayArg(axes, FFIType.i64)
+  const [axes_ptr, axes_len] = arrayArg(axes)
   const requires_stats = tensor.requires_stats
 
   let stats = null
@@ -3584,7 +3584,7 @@ export function countNonzero(
 }
 
 export function any(tensor: Tensor, axes: BigInt64Array | number[] = [], keep_dims = false) {
-  const [axes_ptr, axes_len] = arrayArg(axes, FFIType.i64)
+  const [axes_ptr, axes_len] = arrayArg(axes)
   const requires_stats = tensor.requires_stats
 
   let stats = null
@@ -3627,7 +3627,7 @@ export function any(tensor: Tensor, axes: BigInt64Array | number[] = [], keep_di
 }
 
 export function all(tensor: Tensor, axes: BigInt64Array | number[] = [], keep_dims = false) {
-  const [axes_ptr, axes_len] = arrayArg(axes, FFIType.i64)
+  const [axes_ptr, axes_len] = arrayArg(axes)
   const requires_stats = tensor.requires_stats
 
   let stats = null

--- a/shumai/tensor/tensor_ops_gen.ts
+++ b/shumai/tensor/tensor_ops_gen.ts
@@ -52,7 +52,7 @@ import { Tensor } from './tensor'
   }
 
   const requires_grad = false
-  const deps = requires_grad ? [shape_ptr, shape_len] : []
+  const deps = requires_grad ? [shape] : []
   const t = new Tensor({ _ptr: _ptr, _deps: deps })
   t.provenance = t.requires_grad = requires_grad
   if (requires_stats) {
@@ -110,7 +110,7 @@ import { Tensor } from './tensor'
   }
 
   const requires_grad = false
-  const deps = requires_grad ? [shape_ptr, shape_len] : []
+  const deps = requires_grad ? [shape] : []
   const t = new Tensor({ _ptr: _ptr, _deps: deps })
   t.provenance = t.requires_grad = requires_grad
   if (requires_stats) {
@@ -166,7 +166,7 @@ import { Tensor } from './tensor'
   }
 
   const requires_grad = false
-  const deps = requires_grad ? [shape_ptr, shape_len, Math.fround(val)] : []
+  const deps = requires_grad ? [shape, Math.fround(val)] : []
   const t = new Tensor({ _ptr: _ptr, _deps: deps })
   t.provenance = t.requires_grad = requires_grad
   if (requires_stats) {
@@ -344,7 +344,7 @@ export function eye(dim: number) {
   }
 
   const requires_grad = false
-  const deps = requires_grad ? [dims_ptr, dims_len, tileDims_ptr, tileDims_len] : []
+  const deps = requires_grad ? [dims, tileDims] : []
   const t = new Tensor({ _ptr: _ptr, _deps: deps })
   t.provenance = t.requires_grad = requires_grad
   if (requires_stats) {
@@ -406,7 +406,7 @@ export function eye(dim: number) {
   }
 
   const requires_grad = tensor.requires_grad
-  const deps = requires_grad ? [tensor, shape_ptr, shape_len] : []
+  const deps = requires_grad ? [tensor, shape] : []
   const t = new Tensor({ _ptr: _ptr, _deps: deps })
   t.provenance = tensor.provenance
   t.requires_grad = requires_grad
@@ -472,7 +472,7 @@ export function eye(dim: number) {
   }
 
   const requires_grad = tensor.requires_grad
-  const deps = requires_grad ? [tensor, axes_ptr, axes_len] : []
+  const deps = requires_grad ? [tensor, axes] : []
   const t = new Tensor({ _ptr: _ptr, _deps: deps })
   t.provenance = tensor.provenance
   t.requires_grad = requires_grad
@@ -537,7 +537,7 @@ export function eye(dim: number) {
   }
 
   const requires_grad = tensor.requires_grad
-  const deps = requires_grad ? [tensor, shape_ptr, shape_len] : []
+  const deps = requires_grad ? [tensor, shape] : []
   const t = new Tensor({ _ptr: _ptr, _deps: deps })
   t.provenance = tensor.provenance
   t.requires_grad = requires_grad
@@ -558,7 +558,7 @@ export function concatenate(tensors: Array<Tensor>, axis: number) {
     }
   }
   const [tensors_ptr, tensors_len] = arrayArg(tensors, FFIType.i64)
-  const requires_stats = false
+  const requires_stats = tensors.some((t) => t.requires_stats)
 
   let stats = null
   let recorded_stat = null
@@ -588,10 +588,11 @@ export function concatenate(tensors: Array<Tensor>, axis: number) {
     }
   }
 
-  const requires_grad = false
-  const deps = requires_grad ? [tensors_ptr, tensors_len, axis | 0] : []
+  const requires_grad = tensors.some((t) => t.requires_grad)
+  const deps = requires_grad ? [...tensors, axis | 0] : []
   const t = new Tensor({ _ptr: _ptr, _deps: deps })
-  t.provenance = t.requires_grad = requires_grad
+  t.provenance = tensors.some((t) => t.provenance)
+  t.requires_grad = requires_grad
   if (requires_stats) {
     t.requires_stats = true
     t.stats = stats
@@ -3058,7 +3059,7 @@ export function amin(tensor: Tensor, axes: BigInt64Array | number[] = [], keep_d
   }
 
   const requires_grad = tensor.requires_grad
-  const deps = requires_grad ? [tensor, axes_ptr, axes_len, !!keep_dims] : []
+  const deps = requires_grad ? [tensor, axes, !!keep_dims] : []
   const t = new Tensor({ _ptr: _ptr, _deps: deps })
   t.provenance = tensor.provenance
   t.requires_grad = requires_grad
@@ -3101,7 +3102,7 @@ export function amax(tensor: Tensor, axes: BigInt64Array | number[] = [], keep_d
   }
 
   const requires_grad = tensor.requires_grad
-  const deps = requires_grad ? [tensor, axes_ptr, axes_len, !!keep_dims] : []
+  const deps = requires_grad ? [tensor, axes, !!keep_dims] : []
   const t = new Tensor({ _ptr: _ptr, _deps: deps })
   t.provenance = tensor.provenance
   t.requires_grad = requires_grad
@@ -3228,7 +3229,7 @@ export function sum(tensor: Tensor, axes: BigInt64Array | number[] = [], keep_di
   }
 
   const requires_grad = tensor.requires_grad
-  const deps = requires_grad ? [tensor, axes_ptr, axes_len, !!keep_dims] : []
+  const deps = requires_grad ? [tensor, axes, !!keep_dims] : []
   const t = new Tensor({ _ptr: _ptr, _deps: deps })
   t.provenance = tensor.provenance
   t.requires_grad = requires_grad
@@ -3313,7 +3314,7 @@ export function mean(tensor: Tensor, axes: BigInt64Array | number[] = [], keep_d
   }
 
   const requires_grad = tensor.requires_grad
-  const deps = requires_grad ? [tensor, axes_ptr, axes_len, !!keep_dims] : []
+  const deps = requires_grad ? [tensor, axes, !!keep_dims] : []
   const t = new Tensor({ _ptr: _ptr, _deps: deps })
   t.provenance = tensor.provenance
   t.requires_grad = requires_grad
@@ -3356,7 +3357,7 @@ export function median(tensor: Tensor, axes: BigInt64Array | number[] = [], keep
   }
 
   const requires_grad = tensor.requires_grad
-  const deps = requires_grad ? [tensor, axes_ptr, axes_len, !!keep_dims] : []
+  const deps = requires_grad ? [tensor, axes, !!keep_dims] : []
   const t = new Tensor({ _ptr: _ptr, _deps: deps })
   t.provenance = tensor.provenance
   t.requires_grad = requires_grad
@@ -3404,7 +3405,7 @@ export function _var(
   }
 
   const requires_grad = tensor.requires_grad
-  const deps = requires_grad ? [tensor, axes_ptr, axes_len, !!bias, !!keep_dims] : []
+  const deps = requires_grad ? [tensor, axes, !!bias, !!keep_dims] : []
   const t = new Tensor({ _ptr: _ptr, _deps: deps })
   t.provenance = tensor.provenance
   t.requires_grad = requires_grad
@@ -3456,7 +3457,7 @@ export function std(tensor: Tensor, axes: BigInt64Array | number[] = [], keep_di
   }
 
   const requires_grad = tensor.requires_grad
-  const deps = requires_grad ? [tensor, axes_ptr, axes_len, !!keep_dims] : []
+  const deps = requires_grad ? [tensor, axes, !!keep_dims] : []
   const t = new Tensor({ _ptr: _ptr, _deps: deps })
   t.provenance = tensor.provenance
   t.requires_grad = requires_grad
@@ -3511,7 +3512,7 @@ export function norm(
 
   const requires_grad = tensor.requires_grad
   const deps = requires_grad
-    ? [tensor, axes_ptr, axes_len, p + 0.00000000000001 - 0.00000000000001, !!keep_dims]
+    ? [tensor, axes, p + 0.00000000000001 - 0.00000000000001, !!keep_dims]
     : []
   const t = new Tensor({ _ptr: _ptr, _deps: deps })
   t.provenance = tensor.provenance
@@ -3570,7 +3571,7 @@ export function countNonzero(
   }
 
   const requires_grad = tensor.requires_grad
-  const deps = requires_grad ? [tensor, axes_ptr, axes_len, !!keep_dims] : []
+  const deps = requires_grad ? [tensor, axes, !!keep_dims] : []
   const t = new Tensor({ _ptr: _ptr, _deps: deps })
   t.provenance = tensor.provenance
   t.requires_grad = requires_grad
@@ -3613,7 +3614,7 @@ export function any(tensor: Tensor, axes: BigInt64Array | number[] = [], keep_di
   }
 
   const requires_grad = tensor.requires_grad
-  const deps = requires_grad ? [tensor, axes_ptr, axes_len, !!keep_dims] : []
+  const deps = requires_grad ? [tensor, axes, !!keep_dims] : []
   const t = new Tensor({ _ptr: _ptr, _deps: deps })
   t.provenance = tensor.provenance
   t.requires_grad = requires_grad
@@ -3656,7 +3657,7 @@ export function all(tensor: Tensor, axes: BigInt64Array | number[] = [], keep_di
   }
 
   const requires_grad = tensor.requires_grad
-  const deps = requires_grad ? [tensor, axes_ptr, axes_len, !!keep_dims] : []
+  const deps = requires_grad ? [tensor, axes, !!keep_dims] : []
   const t = new Tensor({ _ptr: _ptr, _deps: deps })
   t.provenance = tensor.provenance
   t.requires_grad = requires_grad

--- a/shumai/tensor/tensor_ops_gen.ts
+++ b/shumai/tensor/tensor_ops_gen.ts
@@ -558,7 +558,7 @@ export function concatenate(tensors: Array<Tensor>, axis: number) {
     }
   }
   const [tensors_ptr, tensors_len] = arrayArg(tensors)
-  const requires_stats = tensors.some((t) => t.requires_stats)
+  const requires_stats = tensors.reduce((r, c) => r || c.requires_stats, false)
 
   let stats = null
   let recorded_stat = null
@@ -588,10 +588,10 @@ export function concatenate(tensors: Array<Tensor>, axis: number) {
     }
   }
 
-  const requires_grad = tensors.some((t) => t.requires_grad)
+  const requires_grad = tensors.reduce((r, c) => r || c.requires_grad, false)
   const deps = requires_grad ? [...tensors, axis | 0] : []
   const t = new Tensor({ _ptr: _ptr, _deps: deps })
-  t.provenance = tensors.some((t) => t.provenance)
+  t.provenance = tensors.reduce((r, c) => r || c.provenance, 0)
   t.requires_grad = requires_grad
   if (requires_stats) {
     t.requires_stats = true

--- a/shumai/tensor/tensor_ops_gen.ts
+++ b/shumai/tensor/tensor_ops_gen.ts
@@ -550,6 +550,13 @@ export function eye(dim: number) {
 }
 
 export function concatenate(tensors: Array<Tensor>, axis: number) {
+  if (axis < 0) {
+    for (let i = 0; i < tensors.length; ++i) {
+      if (tensors[i].shape.length === 0) {
+        tensors[i] = tensors[i].reshape([1])
+      }
+    }
+  }
   const [tensors_ptr, tensors_len] = arrayArg(tensors, FFIType.i64)
   const requires_stats = false
 

--- a/shumai/tensor/tensor_ops_shim_gen.ts
+++ b/shumai/tensor/tensor_ops_shim_gen.ts
@@ -40,7 +40,7 @@ export const gen_tensor_op_shim = (_Tensor: new (...args: unknown[]) => Tensor) 
       }
 
       const requires_grad = this.requires_grad
-      const deps = requires_grad ? [this, shape_ptr, shape_len] : []
+      const deps = requires_grad ? [this, shape] : []
       const t = new _Tensor({ _ptr: _ptr, _deps: deps })
       t.provenance = this.provenance
       t.requires_grad = requires_grad
@@ -85,7 +85,7 @@ export const gen_tensor_op_shim = (_Tensor: new (...args: unknown[]) => Tensor) 
       }
 
       const requires_grad = this.requires_grad
-      const deps = requires_grad ? [this, axes_ptr, axes_len] : []
+      const deps = requires_grad ? [this, axes] : []
       const t = new _Tensor({ _ptr: _ptr, _deps: deps })
       t.provenance = this.provenance
       t.requires_grad = requires_grad
@@ -128,7 +128,7 @@ export const gen_tensor_op_shim = (_Tensor: new (...args: unknown[]) => Tensor) 
       }
 
       const requires_grad = this.requires_grad
-      const deps = requires_grad ? [this, shape_ptr, shape_len] : []
+      const deps = requires_grad ? [this, shape] : []
       const t = new _Tensor({ _ptr: _ptr, _deps: deps })
       t.provenance = this.provenance
       t.requires_grad = requires_grad
@@ -2325,7 +2325,7 @@ export const gen_tensor_op_shim = (_Tensor: new (...args: unknown[]) => Tensor) 
       }
 
       const requires_grad = this.requires_grad
-      const deps = requires_grad ? [this, axes_ptr, axes_len, !!keep_dims] : []
+      const deps = requires_grad ? [this, axes, !!keep_dims] : []
       const t = new _Tensor({ _ptr: _ptr, _deps: deps })
       t.provenance = this.provenance
       t.requires_grad = requires_grad
@@ -2368,7 +2368,7 @@ export const gen_tensor_op_shim = (_Tensor: new (...args: unknown[]) => Tensor) 
       }
 
       const requires_grad = this.requires_grad
-      const deps = requires_grad ? [this, axes_ptr, axes_len, !!keep_dims] : []
+      const deps = requires_grad ? [this, axes, !!keep_dims] : []
       const t = new _Tensor({ _ptr: _ptr, _deps: deps })
       t.provenance = this.provenance
       t.requires_grad = requires_grad
@@ -2499,7 +2499,7 @@ export const gen_tensor_op_shim = (_Tensor: new (...args: unknown[]) => Tensor) 
       }
 
       const requires_grad = this.requires_grad
-      const deps = requires_grad ? [this, axes_ptr, axes_len, !!keep_dims] : []
+      const deps = requires_grad ? [this, axes, !!keep_dims] : []
       const t = new _Tensor({ _ptr: _ptr, _deps: deps })
       t.provenance = this.provenance
       t.requires_grad = requires_grad
@@ -2586,7 +2586,7 @@ export const gen_tensor_op_shim = (_Tensor: new (...args: unknown[]) => Tensor) 
       }
 
       const requires_grad = this.requires_grad
-      const deps = requires_grad ? [this, axes_ptr, axes_len, !!keep_dims] : []
+      const deps = requires_grad ? [this, axes, !!keep_dims] : []
       const t = new _Tensor({ _ptr: _ptr, _deps: deps })
       t.provenance = this.provenance
       t.requires_grad = requires_grad
@@ -2631,7 +2631,7 @@ export const gen_tensor_op_shim = (_Tensor: new (...args: unknown[]) => Tensor) 
       }
 
       const requires_grad = this.requires_grad
-      const deps = requires_grad ? [this, axes_ptr, axes_len, !!keep_dims] : []
+      const deps = requires_grad ? [this, axes, !!keep_dims] : []
       const t = new _Tensor({ _ptr: _ptr, _deps: deps })
       t.provenance = this.provenance
       t.requires_grad = requires_grad
@@ -2674,7 +2674,7 @@ export const gen_tensor_op_shim = (_Tensor: new (...args: unknown[]) => Tensor) 
       }
 
       const requires_grad = this.requires_grad
-      const deps = requires_grad ? [this, axes_ptr, axes_len, !!bias, !!keep_dims] : []
+      const deps = requires_grad ? [this, axes, !!bias, !!keep_dims] : []
       const t = new _Tensor({ _ptr: _ptr, _deps: deps })
       t.provenance = this.provenance
       t.requires_grad = requires_grad
@@ -2721,7 +2721,7 @@ export const gen_tensor_op_shim = (_Tensor: new (...args: unknown[]) => Tensor) 
       }
 
       const requires_grad = this.requires_grad
-      const deps = requires_grad ? [this, axes_ptr, axes_len, !!keep_dims] : []
+      const deps = requires_grad ? [this, axes, !!keep_dims] : []
       const t = new _Tensor({ _ptr: _ptr, _deps: deps })
       t.provenance = this.provenance
       t.requires_grad = requires_grad
@@ -2771,7 +2771,7 @@ export const gen_tensor_op_shim = (_Tensor: new (...args: unknown[]) => Tensor) 
 
       const requires_grad = this.requires_grad
       const deps = requires_grad
-        ? [this, axes_ptr, axes_len, p + 0.00000000000001 - 0.00000000000001, !!keep_dims]
+        ? [this, axes, p + 0.00000000000001 - 0.00000000000001, !!keep_dims]
         : []
       const t = new _Tensor({ _ptr: _ptr, _deps: deps })
       t.provenance = this.provenance
@@ -2821,7 +2821,7 @@ export const gen_tensor_op_shim = (_Tensor: new (...args: unknown[]) => Tensor) 
       }
 
       const requires_grad = this.requires_grad
-      const deps = requires_grad ? [this, axes_ptr, axes_len, !!keep_dims] : []
+      const deps = requires_grad ? [this, axes, !!keep_dims] : []
       const t = new _Tensor({ _ptr: _ptr, _deps: deps })
       t.provenance = this.provenance
       t.requires_grad = requires_grad
@@ -2864,7 +2864,7 @@ export const gen_tensor_op_shim = (_Tensor: new (...args: unknown[]) => Tensor) 
       }
 
       const requires_grad = this.requires_grad
-      const deps = requires_grad ? [this, axes_ptr, axes_len, !!keep_dims] : []
+      const deps = requires_grad ? [this, axes, !!keep_dims] : []
       const t = new _Tensor({ _ptr: _ptr, _deps: deps })
       t.provenance = this.provenance
       t.requires_grad = requires_grad
@@ -2907,7 +2907,7 @@ export const gen_tensor_op_shim = (_Tensor: new (...args: unknown[]) => Tensor) 
       }
 
       const requires_grad = this.requires_grad
-      const deps = requires_grad ? [this, axes_ptr, axes_len, !!keep_dims] : []
+      const deps = requires_grad ? [this, axes, !!keep_dims] : []
       const t = new _Tensor({ _ptr: _ptr, _deps: deps })
       t.provenance = this.provenance
       t.requires_grad = requires_grad

--- a/shumai/tensor/tensor_ops_shim_gen.ts
+++ b/shumai/tensor/tensor_ops_shim_gen.ts
@@ -8,7 +8,7 @@ import type { Tensor } from './tensor'
 export const gen_tensor_op_shim = (_Tensor: new (...args: unknown[]) => Tensor) => {
   return {
     reshape(shape: BigInt64Array | number[]) {
-      const [shape_ptr, shape_len] = arrayArg(shape, FFIType.i64)
+      const [shape_ptr, shape_len] = arrayArg(shape)
       const requires_stats = this.requires_stats
 
       let stats = null
@@ -53,7 +53,7 @@ export const gen_tensor_op_shim = (_Tensor: new (...args: unknown[]) => Tensor) 
     },
 
     transpose(axes: BigInt64Array | number[]) {
-      const [axes_ptr, axes_len] = arrayArg(axes, FFIType.i64)
+      const [axes_ptr, axes_len] = arrayArg(axes)
       const requires_stats = this.requires_stats
 
       let stats = null
@@ -98,7 +98,7 @@ export const gen_tensor_op_shim = (_Tensor: new (...args: unknown[]) => Tensor) 
     },
 
     tile(shape: BigInt64Array | number[]) {
-      const [shape_ptr, shape_len] = arrayArg(shape, FFIType.i64)
+      const [shape_ptr, shape_len] = arrayArg(shape)
       const requires_stats = this.requires_stats
 
       let stats = null
@@ -2295,7 +2295,7 @@ export const gen_tensor_op_shim = (_Tensor: new (...args: unknown[]) => Tensor) 
     },
 
     amin(axes: BigInt64Array | number[] = [], keep_dims = false) {
-      const [axes_ptr, axes_len] = arrayArg(axes, FFIType.i64)
+      const [axes_ptr, axes_len] = arrayArg(axes)
       const requires_stats = this.requires_stats
 
       let stats = null
@@ -2338,7 +2338,7 @@ export const gen_tensor_op_shim = (_Tensor: new (...args: unknown[]) => Tensor) 
     },
 
     amax(axes: BigInt64Array | number[] = [], keep_dims = false) {
-      const [axes_ptr, axes_len] = arrayArg(axes, FFIType.i64)
+      const [axes_ptr, axes_len] = arrayArg(axes)
       const requires_stats = this.requires_stats
 
       let stats = null
@@ -2469,7 +2469,7 @@ export const gen_tensor_op_shim = (_Tensor: new (...args: unknown[]) => Tensor) 
     },
 
     sum(axes: BigInt64Array | number[] = [], keep_dims = false) {
-      const [axes_ptr, axes_len] = arrayArg(axes, FFIType.i64)
+      const [axes_ptr, axes_len] = arrayArg(axes)
       const requires_stats = this.requires_stats
 
       let stats = null
@@ -2556,7 +2556,7 @@ export const gen_tensor_op_shim = (_Tensor: new (...args: unknown[]) => Tensor) 
     },
 
     mean(axes: BigInt64Array | number[] = [], keep_dims = false) {
-      const [axes_ptr, axes_len] = arrayArg(axes, FFIType.i64)
+      const [axes_ptr, axes_len] = arrayArg(axes)
       const requires_stats = this.requires_stats
 
       let stats = null
@@ -2599,7 +2599,7 @@ export const gen_tensor_op_shim = (_Tensor: new (...args: unknown[]) => Tensor) 
     },
 
     median(axes: BigInt64Array | number[] = [], keep_dims = false) {
-      const [axes_ptr, axes_len] = arrayArg(axes, FFIType.i64)
+      const [axes_ptr, axes_len] = arrayArg(axes)
       const requires_stats = this.requires_stats
 
       let stats = null
@@ -2644,7 +2644,7 @@ export const gen_tensor_op_shim = (_Tensor: new (...args: unknown[]) => Tensor) 
     },
 
     _var(axes: BigInt64Array | number[] = [], bias = false, keep_dims = false) {
-      const [axes_ptr, axes_len] = arrayArg(axes, FFIType.i64)
+      const [axes_ptr, axes_len] = arrayArg(axes)
       const requires_stats = this.requires_stats
 
       let stats = null
@@ -2691,7 +2691,7 @@ export const gen_tensor_op_shim = (_Tensor: new (...args: unknown[]) => Tensor) 
     },
 
     std(axes: BigInt64Array | number[] = [], keep_dims = false) {
-      const [axes_ptr, axes_len] = arrayArg(axes, FFIType.i64)
+      const [axes_ptr, axes_len] = arrayArg(axes)
       const requires_stats = this.requires_stats
 
       let stats = null
@@ -2734,7 +2734,7 @@ export const gen_tensor_op_shim = (_Tensor: new (...args: unknown[]) => Tensor) 
     },
 
     norm(axes: BigInt64Array | number[] = [], p = 2, keep_dims = false) {
-      const [axes_ptr, axes_len] = arrayArg(axes, FFIType.i64)
+      const [axes_ptr, axes_len] = arrayArg(axes)
       const requires_stats = this.requires_stats
 
       let stats = null
@@ -2789,7 +2789,7 @@ export const gen_tensor_op_shim = (_Tensor: new (...args: unknown[]) => Tensor) 
     },
 
     countNonzero(axes: BigInt64Array | number[] = [], keep_dims = false) {
-      const [axes_ptr, axes_len] = arrayArg(axes, FFIType.i64)
+      const [axes_ptr, axes_len] = arrayArg(axes)
       const requires_stats = this.requires_stats
 
       let stats = null
@@ -2834,7 +2834,7 @@ export const gen_tensor_op_shim = (_Tensor: new (...args: unknown[]) => Tensor) 
     },
 
     any(axes: BigInt64Array | number[] = [], keep_dims = false) {
-      const [axes_ptr, axes_len] = arrayArg(axes, FFIType.i64)
+      const [axes_ptr, axes_len] = arrayArg(axes)
       const requires_stats = this.requires_stats
 
       let stats = null
@@ -2877,7 +2877,7 @@ export const gen_tensor_op_shim = (_Tensor: new (...args: unknown[]) => Tensor) 
     },
 
     all(axes: BigInt64Array | number[] = [], keep_dims = false) {
-      const [axes_ptr, axes_len] = arrayArg(axes, FFIType.i64)
+      const [axes_ptr, axes_len] = arrayArg(axes)
       const requires_stats = this.requires_stats
 
       let stats = null

--- a/test/concatenate.test.ts
+++ b/test/concatenate.test.ts
@@ -1,0 +1,240 @@
+import { describe, expect, it } from 'bun:test'
+import * as sm from '@shumai/shumai'
+import { expectArraysClose, expectThrows, nativeError, isClose, isShape } from './utils'
+
+describe('concatenate', () => {
+  it('scalar tensors invalid dims', () => {
+    const a = sm.scalar(0)
+    const b = sm.scalar(10)
+
+    expectThrows(() => sm.concatenate([a, b], 0), nativeError)
+    expectThrows(() => sm.concatenate([a, b], 1), nativeError)
+  })
+  it('scalar tensors expand dims', () => {
+    const a = sm.scalar(0)
+    const b = sm.scalar(10)
+    const result0 = sm.concatenate([a, b], -1)
+    const expectedArray0 = new Float32Array([0, 10])
+    const expectedShape0 = [2]
+    expectArraysClose(result0.toFloat32Array(), expectedArray0)
+    expect(isShape(result0, expectedShape0)).toBe(true)
+
+    const result1 = sm.concatenate([a, b], -2)
+    const expectedArray1 = expectedArray0
+    const expectedShape1 = [2, 1]
+    expectArraysClose(result1.toFloat32Array(), expectedArray1)
+    expect(isShape(result1, expectedShape1)).toBe(true)
+  })
+  it('1D tensors', () => {
+    const a = sm.tensor(new Float32Array([0, 1, 2, 3, 4, 5]))
+    const b = sm.tensor(new Float32Array([10, 11, 12, 13, 14, 15]))
+
+    const result = sm.concatenate([a, b], 0)
+    const expectedArray = new Float32Array([0, 1, 2, 3, 4, 5, 10, 11, 12, 13, 14, 15])
+    const expectedShape = [12]
+    expectArraysClose(result.toFloat32Array(), expectedArray)
+    expect(isShape(result, expectedShape)).toBe(true)
+  })
+  it('1D tensors different sizes', () => {
+    const a = sm.tensor(new Float32Array([0, 1, 2, 3, 4, 5]))
+    const b = sm.tensor(new Float32Array([10, 11, 12]))
+
+    const result = sm.concatenate([a, b], 0)
+    const expectedArray = new Float32Array([0, 1, 2, 3, 4, 5, 10, 11, 12])
+    const expectedShape = [9]
+    expectArraysClose(result.toFloat32Array(), expectedArray)
+    expect(isShape(result, expectedShape)).toBe(true)
+  })
+  it('1D singleton tensors', () => {
+    const a = sm.tensor(new Float32Array([0]))
+    const b = sm.tensor(new Float32Array([10]))
+
+    const result = sm.concatenate([a, b], 0)
+    const expectedArray = new Float32Array([0, 10])
+    const expectedShape = [2]
+    expectArraysClose(result.toFloat32Array(), expectedArray)
+    expect(isShape(result, expectedShape)).toBe(true)
+  })
+  it('1D tensors last dim', () => {
+    const a = sm.tensor(new Float32Array([0, 1, 2, 3, 4, 5]))
+    const b = sm.tensor(new Float32Array([10, 11, 12, 13, 14, 15]))
+
+    const result = sm.concatenate([a, b], -1)
+    const expectedArray = new Float32Array([0, 1, 2, 3, 4, 5, 10, 11, 12, 13, 14, 15])
+    const expectedShape = [12]
+    expectArraysClose(result.toFloat32Array(), expectedArray)
+    expect(isShape(result, expectedShape)).toBe(true)
+  })
+  it('1D tensors expand dims', () => {
+    const a = sm.tensor(new Float32Array([0, 1, 2, 3, 4, 5]))
+    const b = sm.tensor(new Float32Array([10, 11, 12, 13, 14, 15]))
+
+    const result0 = sm.concatenate([a, b], -2)
+    const expectedArray0 = new Float32Array([0, 1, 2, 3, 4, 5, 10, 11, 12, 13, 14, 15])
+    const expectedShape0 = [2, 6]
+    expectArraysClose(result0.toFloat32Array(), expectedArray0)
+    expect(isShape(result0, expectedShape0)).toBe(true)
+
+    const result1 = sm.concatenate([a, b], -3)
+    const expectedArray1 = expectedArray0
+    const expectedShape1 = [2, 1, 6]
+    expectArraysClose(result1.toFloat32Array(), expectedArray1)
+    expect(isShape(result1, expectedShape1)).toBe(true)
+  })
+  it('1D tensors invalid dim', () => {
+    const a = sm.tensor(new Float32Array([0, 1, 2, 3, 4, 5]))
+    const b = sm.tensor(new Float32Array([10, 11, 12, 13, 14, 15]))
+
+    expectThrows(() => sm.concatenate([a, b], 1), nativeError)
+  })
+  it('1D tensors multiple', () => {
+    const tensors = Array.from(Array(4), (x, i) =>
+      sm.tensor(new Float32Array([i * 10, i * 10 + 1, i * 10 + 2]))
+    )
+
+    const result = sm.concatenate(tensors, 0)
+    const expectedArray = new Float32Array([0, 1, 2, 10, 11, 12, 20, 21, 22, 30, 31, 32])
+    const expectedShape = [12]
+    expectArraysClose(result.toFloat32Array(), expectedArray)
+    expect(isShape(result, expectedShape)).toBe(true)
+  })
+  it('1D tensors too many', () => {
+    const tensors = Array.from(Array(5), (x, i) =>
+      sm.tensor(new Float32Array([i * 10, i * 10 + 1, i * 10 + 2]))
+    )
+    expectThrows(() => sm.concatenate(tensors, 0), nativeError)
+  })
+  it('2D tensors', () => {
+    const a = sm.tensor(new Float32Array([0, 1, 2, 3, 4, 5])).reshape([3, 2])
+    const b = sm.tensor(new Float32Array([10, 11, 12, 13, 14, 15])).reshape([3, 2])
+
+    const result0 = sm.concatenate([a, b], 0)
+    const expectedArray0 = new Float32Array([0, 1, 2, 3, 4, 5, 10, 11, 12, 13, 14, 15])
+    const expectedShape0 = [6, 2]
+    expectArraysClose(result0.toFloat32Array(), expectedArray0)
+    expect(isShape(result0, expectedShape0)).toBe(true)
+
+    const result1 = sm.concatenate([a, b], 1)
+    const expectedArray1 = new Float32Array([0, 1, 10, 11, 2, 3, 12, 13, 4, 5, 14, 15])
+    const expectedShape1 = [3, 4]
+    expectArraysClose(result1.toFloat32Array(), expectedArray1)
+    expect(isShape(result1, expectedShape1)).toBe(true)
+  })
+  it('2D tensors different sizes', () => {
+    const a0 = sm.tensor(new Float32Array([0, 1, 2, 3, 4, 5])).reshape([3, 2])
+    const b0 = sm.tensor(new Float32Array([10, 11])).reshape([1, 2])
+
+    const result0 = sm.concatenate([a0, b0], 0)
+    const expectedArray0 = new Float32Array([0, 1, 2, 3, 4, 5, 10, 11])
+    const expectedShape0 = [4, 2]
+    expectArraysClose(result0.toFloat32Array(), expectedArray0)
+    expect(isShape(result0, expectedShape0)).toBe(true)
+
+    const a1 = sm.tensor(new Float32Array([0, 1, 2, 3, 4, 5])).reshape([3, 2])
+    const b1 = sm.tensor(new Float32Array([10, 11, 12])).reshape([3, 1])
+
+    const result1 = sm.concatenate([a1, b1], 1)
+    const expectedArray1 = new Float32Array([0, 1, 10, 2, 3, 11, 4, 5, 12])
+    const expectedShape1 = [3, 3]
+    expectArraysClose(result1.toFloat32Array(), expectedArray1)
+    expect(isShape(result1, expectedShape1)).toBe(true)
+  })
+  it('2D singleton tensors', () => {
+    const a = sm.tensor(new Float32Array([0])).reshape([1, 1])
+    const b = sm.tensor(new Float32Array([10])).reshape([1, 1])
+
+    const result0 = sm.concatenate([a, b], 0)
+    const expectedArray0 = new Float32Array([0, 10])
+    const expectedShape0 = [2, 1]
+    expectArraysClose(result0.toFloat32Array(), expectedArray0)
+    expect(isShape(result0, expectedShape0)).toBe(true)
+
+    const result1 = sm.concatenate([a, b], 1)
+    const expectedArray1 = expectedArray0
+    const expectedShape1 = [1, 2]
+    expectArraysClose(result1.toFloat32Array(), expectedArray1)
+    expect(isShape(result1, expectedShape1)).toBe(true)
+  })
+  it('2D tensors last dims', () => {
+    const a = sm.tensor(new Float32Array([0, 1, 2, 3, 4, 5])).reshape([3, 2])
+    const b = sm.tensor(new Float32Array([10, 11, 12, 13, 14, 15])).reshape([3, 2])
+
+    const result1 = sm.concatenate([a, b], -1)
+    const expectedArray1 = new Float32Array([0, 1, 10, 11, 2, 3, 12, 13, 4, 5, 14, 15])
+    const expectedShape1 = [3, 4]
+    expectArraysClose(result1.toFloat32Array(), expectedArray1)
+    expect(isShape(result1, expectedShape1)).toBe(true)
+
+    const result0 = sm.concatenate([a, b], -2)
+    const expectedArray0 = new Float32Array([0, 1, 2, 3, 4, 5, 10, 11, 12, 13, 14, 15])
+    const expectedShape0 = [6, 2]
+    expectArraysClose(result0.toFloat32Array(), expectedArray0)
+    expect(isShape(result0, expectedShape0)).toBe(true)
+  })
+  it('2D tensors expand dims', () => {
+    const a = sm.tensor(new Float32Array([0, 1, 2, 3, 4, 5])).reshape([3, 2])
+    const b = sm.tensor(new Float32Array([10, 11, 12, 13, 14, 15])).reshape([3, 2])
+
+    const result0 = sm.concatenate([a, b], -3)
+    const expectedArray0 = new Float32Array([0, 1, 2, 3, 4, 5, 10, 11, 12, 13, 14, 15])
+    const expectedShape0 = [2, 3, 2]
+    expectArraysClose(result0.toFloat32Array(), expectedArray0)
+    expect(isShape(result0, expectedShape0)).toBe(true)
+
+    const result1 = sm.concatenate([a, b], -4)
+    const expectedArray1 = expectedArray0
+    const expectedShape1 = [2, 1, 3, 2]
+    expectArraysClose(result1.toFloat32Array(), expectedArray1)
+    expect(isShape(result1, expectedShape1)).toBe(true)
+  })
+  it('2D tensors invalid dim', () => {
+    const a = sm.tensor(new Float32Array([0, 1, 2, 3, 4, 5])).reshape([3, 2])
+    const b = sm.tensor(new Float32Array([10, 11, 12, 13, 14, 15])).reshape([3, 2])
+
+    expectThrows(() => sm.concatenate([a, b], 2), nativeError)
+  })
+  it('2D tensors multiple', () => {
+    const tensors = Array.from(Array(4), (x, i) =>
+      sm.tensor(new Float32Array(Array.from(Array(6), (y, j) => i * 10 + j))).reshape([3, 2])
+    )
+
+    const result0 = sm.concatenate(tensors, 0)
+    const expectedArray0 = new Float32Array([
+      0, 1, 2, 3, 4, 5, 10, 11, 12, 13, 14, 15, 20, 21, 22, 23, 24, 25, 30, 31, 32, 33, 34, 35
+    ])
+    const expectedShape0 = [12, 2]
+    expectArraysClose(result0.toFloat32Array(), expectedArray0)
+    expect(isShape(result0, expectedShape0)).toBe(true)
+
+    const result1 = sm.concatenate(tensors, 1)
+    const expectedArray1 = new Float32Array([
+      0, 1, 10, 11, 20, 21, 30, 31, 2, 3, 12, 13, 22, 23, 32, 33, 4, 5, 14, 15, 24, 25, 34, 35
+    ])
+    const expectedShape1 = [3, 8]
+    expectArraysClose(result1.toFloat32Array(), expectedArray1)
+    expect(isShape(result1, expectedShape1)).toBe(true)
+  })
+  it('2D tensors too many', () => {
+    const tensors = Array.from(Array(5), (x, i) =>
+      sm.tensor(new Float32Array(Array.from(Array(6), (y, j) => i * 10 + j))).reshape([3, 2])
+    )
+    expectThrows(() => sm.concatenate(tensors, 0), nativeError)
+    expectThrows(() => sm.concatenate(tensors, 1), nativeError)
+  })
+  it('propagates NaNs', () => {
+    const a = sm.tensor(new Float32Array([NaN, 1, 2, 3, NaN, 5])).reshape([3, 2])
+    const b = sm.tensor(new Float32Array([NaN, 11, 12, 13, 14, NaN])).reshape([3, 2])
+
+    const concat0 = sm.concatenate([a, b], 0)
+    const expectedArray0 = new Float32Array([NaN, 1, 2, 3, NaN, 5, NaN, 11, 12, 13, 14, NaN])
+    const expectedShape0 = [6, 2]
+    expectArraysClose(concat0.toFloat32Array(), expectedArray0)
+    expect(isShape(concat0, expectedShape0)).toBe(true)
+
+    const concat1 = sm.concatenate([a, b], 1)
+    const expectedArray1 = new Float32Array([NaN, 1, NaN, 11, 2, 3, 12, 13, NaN, 5, 14, NaN])
+    const expectedShape1 = [3, 4]
+    expectArraysClose(concat1.toFloat32Array(), expectedArray1)
+    expect(isShape(concat1, expectedShape1)).toBe(true)
+  })
+})

--- a/test/concatenate.test.ts
+++ b/test/concatenate.test.ts
@@ -237,4 +237,44 @@ describe('concatenate', () => {
     expectArraysClose(concat1.toFloat32Array(), expectedArray1)
     expect(isShape(concat1, expectedShape1)).toBe(true)
   })
+  it('gradient', () => {
+    const a = sm
+      .tensor(new Float32Array([0, 1, 2, 3, 4, 5]))
+      .reshape([3, 2])
+      .requireGrad()
+    const b = sm
+      .tensor(new Float32Array([10, 11, 12, 13, 14, 15]))
+      .reshape([3, 2])
+      .requireGrad()
+
+    const out = sm.concatenate([a, b], 0)
+    out.backward()
+    const expectedGradShape = [3, 2]
+    const expectedGrad = sm.full(expectedGradShape, 1)
+    const expectedGradArray = expectedGrad.toFloat32Array()
+    expectArraysClose(a.grad.toFloat32Array(), expectedGradArray)
+    expectArraysClose(b.grad.toFloat32Array(), expectedGradArray)
+    expect(isShape(a.grad, expectedGradShape)).toBe(true)
+    expect(isShape(b.grad, expectedGradShape)).toBe(true)
+  })
+  it('gradient from mean', () => {
+    const a = sm
+      .tensor(new Float32Array([0, 1, 2, 3, 4, 5]))
+      .reshape([3, 2])
+      .requireGrad()
+    const b = sm
+      .tensor(new Float32Array([10, 11, 12, 13, 14, 15]))
+      .reshape([3, 2])
+      .requireGrad()
+
+    const out = sm.concatenate([a, b], 0).mean()
+    out.backward()
+    const expectedGradShape = [3, 2]
+    const expectedGrad = sm.full(expectedGradShape, 1 / 12)
+    const expectedGradArray = expectedGrad.toFloat32Array()
+    expectArraysClose(a.grad.toFloat32Array(), expectedGradArray)
+    expectArraysClose(b.grad.toFloat32Array(), expectedGradArray)
+    expect(isShape(a.grad, expectedGradShape)).toBe(true)
+    expect(isShape(b.grad, expectedGradShape)).toBe(true)
+  })
 })

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -2,6 +2,10 @@ import { expect } from 'bun:test'
 import type { Tensor } from '@shumai/shumai'
 import { util } from '@shumai/shumai'
 
+export const nativeError = new RegExp(
+  '^Tensor returned.*is null; native code likely threw an error'
+)
+
 export const calcSizeFromShape = (arr: number[]) =>
   arr.reduce((acc, val, i) => (i === 0 ? val : acc * val), 0)
 


### PR DESCRIPTION
For each TensorVector, a Typescript `Array<Tensor>` is converted to a `BigInt64Array` containing pointers to `Tensor`s. This is passed to the FFI as `tensors_ptr` and `tensors_len` which have types `FFIType.ptr` and `FFIType.i64`. In C++, we cast each `uint64_t` in the array to `fl::Tensor*` and dereference it to obtain `std::vector<fl::Tensor>`, which is the type Flashlight expects.

### Gradient dependencies

TensorVector is unfolded into individual Tensors before being passed to gradient calculations. As a consequence of this, in general each function can only take at most one TensorVector parameter; if there were multiple TensorVector parameters, the gradient function would be unable to distinguish which TensorVector a given Tensor came from (without some horrible hacks). The alternative would have been to pass TensorVectors as-is, but I think that would require modifying the `Grad` interface to include a "sub-index" field, which I'm not sure is desirable.

Changed `Grad.in` interface from `Tensor[]` to `any[]`, which it already was de facto since `Tensor.deps` contained non-Tensor parameters as well. Calculating the gradient of `sm.concatenate` is much more straightforward when the `axis` parameter is available.

Since these `Tensor.deps` are being used within Typescript itself, and not being passed to the FFI, I changed the codegen to keep them as Typescript-native types. Previously, they were stored as the same ptr, len pairs that were passed to the FFI.

### `sm.concatenate`

Flashlight's concatenate seems to support automatic expanding the dimensionality of resultant Tensors when a negative `axis` is passed. This functionality is preserved in the Typescript bindings, and reflected in the tests. However, Flashlight behaves inconsistently when a 0-dimensional Tensors are passed with a negative `axis`, always returning an unconcatenated 0-dimensional Tensor instead of expanding its dimensionality and concatenating it. I added a bit of logic to make `sm.concatenate` treat scalar Tensors consistently as well.

### `Tensor.index`

Changed this method to take ranges in the form of `'0:3'` to take a slice of the Tensor from the 0th to the 2nd index (inclusive) in that particular dimension. E.g.: `sm.full([2, 3, 4], 1).index([1, ':', '0:2'])`.

This was needed to get the gradient of `sm.concatenate`.