### PR TITLE
Try alternate python command in gen_all_binding.sh

### DIFF
--- a/scripts/gen_all_binding.sh
+++ b/scripts/gen_all_binding.sh
@@ -1,10 +1,15 @@
 #!/bin/bash
 
-python scripts/gen_binding.py ffi > shumai/ffi/ffi_tensor_ops_gen.ts
-python scripts/gen_binding.py js > shumai/tensor/tensor_ops_gen.ts
-python scripts/gen_binding.py js_methods > shumai/tensor/tensor_ops_shim_gen.ts
-python scripts/gen_binding.py js_ops_interface > shumai/tensor/tensor_ops_interface_gen.ts
-python scripts/gen_binding.py c > shumai/cpp/binding_gen.inl
+PYTHON_COMMAND="$(type -P "python3" 2> /dev/null)"
+PYTHON_COMMAND="${PYTHON_COMMAND:-"$(type -P "python" 2> /dev/null)"}"
+
+"$PYTHON_COMMAND" scripts/gen_binding.py ffi > shumai/ffi/ffi_tensor_ops_gen.ts
+"$PYTHON_COMMAND" scripts/gen_binding.py js > shumai/tensor/tensor_ops_gen.ts
+"$PYTHON_COMMAND" scripts/gen_binding.py js_methods > shumai/tensor/tensor_ops_shim_gen.ts
+"$PYTHON_COMMAND" scripts/gen_binding.py js_ops_interface > shumai/tensor/tensor_ops_interface_gen.ts
+"$PYTHON_COMMAND" scripts/gen_binding.py c > shumai/cpp/binding_gen.inl
 echo "beautifying javascript & formatting python"
 bun format
 clang-format -i shumai/cpp/binding_gen.inl shumai/cpp/flashlight_binding.cc
+
+unset PYTHON_COMMAND


### PR DESCRIPTION
Some systems might not have a `python` executable, or it might point to Python 2 instead. For better compatibility, try to use `python3` first, then fall back to `python` if that is not found.

`type -P` searches the system PATH and returns the path to the executable if it is found
`${VAR:-string}` returns `string` if `VAR` is unset.