### PR TITLE
Manually append nullbyte when encoding String for FFI arg

### DIFF
--- a/shumai/tensor/tensor.ts
+++ b/shumai/tensor/tensor.ts
@@ -283,7 +283,7 @@ export class Tensor {
       return
     }
     if (typeof obj === 'string') {
-      this._injest_ptr(fl.load(new TextEncoder().encode(obj)))
+      this._injest_ptr(fl.load(new TextEncoder().encode(obj + '/0')))
       return
     }
     if (obj.constructor === Float32Array) {


### PR DESCRIPTION
Dug into Bun's issues a bit and seems as though we might need to manually append the null byte to the end of the string when encoding for FFI: https://github.com/oven-sh/bun/issues/801


As I'm running locally on Darwin/arm64, going to PR as draft and see whether resolves against test CI.