### PR TITLE
Transformer multi-head attention

### DIFF
--- a/shumai/module/index.ts
+++ b/shumai/module/index.ts
@@ -1,3 +1,4 @@
 export * from './module'
 export * from './linear'
 export * from './lstm'
+export * from './transformer'

--- a/shumai/module/transformer.ts
+++ b/shumai/module/transformer.ts
@@ -1,0 +1,128 @@
+import * as ops from '../tensor/tensor_ops_gen'
+import * as tensor from '../tensor/tensor'
+import * as module from './index'
+import * as util from '../util'
+
+import { Module } from './module'
+import type { Tensor } from '../tensor'
+
+const sm = { ...ops, ...tensor, module, util }
+
+export class TransformerDotProductAttention extends Module {
+  private dim: number
+  private scale_factor: Tensor
+
+  constructor(dim: number) {
+    super()
+    this.dim = dim
+    this.scale_factor = sm.scalar(1 / Math.sqrt(dim))
+  }
+
+  protected scale(tensor: Tensor): Tensor {
+    return tensor.mul(this.scale_factor)
+  }
+
+  forward(queries: Tensor, keys: Tensor, values: Tensor): Tensor {
+    // shape [..., tokens, dim]
+    const shape = queries.shape
+    for (let i = 0; i < shape.length; i++) {
+      if (shape[i] !== keys.shape[i] || shape[i] !== values.shape[i]) {
+        throw new Error(
+          `Input tensors should have the same shape: queries shape ${shape}, keys shape ${keys.shape}, values shape ${values.shape}`
+        )
+      }
+    }
+
+    const dim = shape[shape.length - 1]
+    if (dim !== this.dim) {
+      throw new Error(
+        `Last axis of input tensors (shape ${shape}) must match module dimensions (${this.dim})`
+      )
+    }
+
+    let output = queries.matmul(keys.T()) // shape [..., tokens, tokens]
+    output = this.scale(output).softmax(-1)
+    output = output.matmul(values) // shape [..., tokens, dim]
+    return output
+  }
+}
+
+export class TransformerMultiheadAttention extends Module {
+  private dim: number
+  private heads: number
+  private attn_dim: number
+  private query_embed: sm.module.Linear
+  private key_embed: sm.module.Linear
+  private value_embed: sm.module.Linear
+  private attention: TransformerDotProductAttention
+  private concat_embed: sm.module.Linear
+
+  constructor(dim: number, heads: number, attn_dim?: number) {
+    super()
+
+    if (dim % heads !== 0) {
+      throw new Error(
+        `Model dimensions must be divisible by the number of heads: ${dim} not divisible by ${heads}`
+      )
+    }
+
+    this.dim = dim
+    this.heads = heads
+    if (attn_dim === undefined) {
+      this.attn_dim = dim / heads
+    } else {
+      this.attn_dim = attn_dim
+    }
+    this.query_embed = new sm.module.Linear(dim, this.attn_dim * heads)
+    this.key_embed = new sm.module.Linear(dim, this.attn_dim * heads)
+    this.value_embed = new sm.module.Linear(dim, this.attn_dim * heads)
+    this.attention = new TransformerDotProductAttention(this.attn_dim)
+    this.concat_embed = new sm.module.Linear(this.attn_dim * heads, dim)
+  }
+
+  forward(queries: Tensor, keys: Tensor, values: Tensor): Tensor {
+    // shape [..., tokens, dim]
+    const shape = queries.shape
+    for (let i = 0; i < shape.length; i++) {
+      if (shape[i] !== keys.shape[i] || shape[i] !== values.shape[i]) {
+        throw new Error(
+          `Input tensors should have the same shape: queries shape ${shape}, keys shape ${keys.shape}, values shape ${values.shape}`
+        )
+      }
+    }
+
+    const dim = shape[shape.length - 1]
+    if (dim !== this.dim) {
+      throw new Error(
+        `Last axis of input tensors (shape ${shape}) must match module dimensions (${this.dim})`
+      )
+    }
+
+    const reshape = [...shape] // [..., tokens, dim]
+    reshape[reshape.length - 1] = this.heads
+    reshape.push(this.attn_dim) // [..., tokens, heads, attn_dim]
+
+    // Swap 2nd and 3rd last axes
+    const transpose = Array.from(sm.util.range(reshape.length))
+    transpose[transpose.length - 3] = transpose.length - 2
+    transpose[transpose.length - 2] = transpose.length - 3
+
+    queries = this.query_embed(queries).reshape(reshape).transpose(transpose)
+    keys = this.key_embed(keys).reshape(reshape).transpose(transpose)
+    values = this.value_embed(values).reshape(reshape).transpose(transpose)
+    // embed shape [..., tokens, heads * attn_dim]
+    // reshape shape [..., tokens, heads, attn_dim]
+    // transpose shape [..., heads, tokens, attn_dim]
+
+    const reverseTranspose = transpose
+    const reverseReshape = [...shape]
+    reverseReshape[reverseReshape.length - 1] = this.heads * this.attn_dim
+
+    let output = this.attention(queries, keys, values) // shape [..., heads, tokens, attn_dim]
+    output = output.transpose(reverseTranspose) // shape [..., tokens, heads, attn_dim]
+    output = output.reshape(reverseReshape) // shape [..., tokens, heads * attn_dim]
+    output = this.concat_embed(output) // shape [batch, tokens, dim]
+
+    return output
+  }
+}

--- a/shumai/tensor/register_gradients.ts
+++ b/shumai/tensor/register_gradients.ts
@@ -115,11 +115,13 @@ const impls = {
   },
   matmul: (grad: Grad) => {
     if (grad.idx === 0) {
-      const yT = grad.in[1].transpose([1, 0])
+      const yT = (grad.in[1] as Tensor).T()
       return grad.grad_in.matmul(yT)
     } else if (grad.idx === 1) {
-      const xT = grad.in[0].transpose([1, 0])
+      const xT = (grad.in[0] as Tensor).T()
       return xT.matmul(grad.grad_in)
+    } else {
+      throw new Error(`Invalid Grad argument`)
     }
   },
   maximum: (grad: Grad) => {

--- a/shumai/tensor/tensor.ts
+++ b/shumai/tensor/tensor.ts
@@ -615,6 +615,13 @@ export class Tensor {
     )
   }
 
+  T(): Tensor {
+    const axes = this.shape.map((x, i) => i)
+    axes[axes.length - 1] = axes.length - 2
+    axes[axes.length - 2] = axes.length - 1
+    return this.transpose(axes)
+  }
+
   softmax(axis: number): Tensor {
     return ops.softmax(this, axis)
   }

--- a/test/transformer.test.ts
+++ b/test/transformer.test.ts
@@ -1,0 +1,330 @@
+import { expect, describe, it } from 'bun:test'
+import * as sm from '@shumai/shumai'
+import { areSameShape, expectArraysClose, expectThrows } from './utils'
+
+describe('TransformerDotProductAttention', () => {
+  it('single matching token', () => {
+    const module = new sm.module.TransformerDotProductAttention(3)
+    const queries = sm.tensor(new Float32Array([0, 0, 1])).reshape([1, 3])
+    const keys = sm.tensor(new Float32Array([0, 0, 0.5])).reshape([1, 3])
+    const values = sm.tensor(new Float32Array([1, 0, 0])).reshape([1, 3])
+
+    const result = module(queries, keys, values)
+    const expected = [1, 0, 0]
+    expectArraysClose(result.toFloat32Array(), expected)
+    areSameShape(result, queries)
+  })
+  it('single dissimilar token', () => {
+    const module = new sm.module.TransformerDotProductAttention(3)
+    const queries = sm.tensor(new Float32Array([0, 0, 1])).reshape([1, 3])
+    const keys = sm.tensor(new Float32Array([0, 0.5, 0])).reshape([1, 3])
+    const values = sm.tensor(new Float32Array([1, 0, 0])).reshape([1, 3])
+
+    const result = module(queries, keys, values)
+    const expected = [1, 0, 0]
+    expectArraysClose(result.toFloat32Array(), expected)
+    areSameShape(result, queries)
+  })
+  it('two tokens', () => {
+    const module = new sm.module.TransformerDotProductAttention(3)
+
+    const queries = sm.tensor(new Float32Array([0, 0, 1, 0, 1, 0])).reshape([2, 3])
+    const keys = sm.tensor(new Float32Array([0, 1, 0.25, 0, 0.5, 1])).reshape([2, 3])
+    const values = sm.tensor(new Float32Array([1, 0, 0, 0, 1, 0])).reshape([2, 3])
+
+    const result = module(queries, keys, values)
+    areSameShape(result, queries)
+
+    // Result 0 is more value 1 than value 0
+    expect(result.index([0, 1]).toFloat32() > result.index([0, 0]).toFloat32()).toBe(true)
+
+    // Result 1 is more value 0 than value 1
+    expect(result.index([1, 0]).toFloat32() > result.index([1, 1]).toFloat32()).toBe(true)
+
+    // Query 0 is more skewed than query 1
+    expect(result.index([0, 1]).toFloat32() > result.index([1, 0]).toFloat32()).toBe(true)
+    expect(result.index([0, 0]).toFloat32() < result.index([1, 1]).toFloat32()).toBe(true)
+  })
+  it('batch samples are independent', () => {
+    const module = new sm.module.TransformerDotProductAttention(3)
+
+    const singleQueries = sm.tensor(new Float32Array([0, 0, 1, 0, 1, 0])).reshape([2, 3])
+    const singleKeys = sm.tensor(new Float32Array([0, 1, 0.25, 0, 0.5, 1])).reshape([2, 3])
+    const singleValues = sm.tensor(new Float32Array([1, 0, 0, 0, 1, 0])).reshape([2, 3])
+
+    const batchQueries = sm
+      .tensor(
+        new Float32Array(
+          [0, 0, 1, 0, 1, 0].concat([
+            Math.random(),
+            Math.random(),
+            Math.random(),
+            Math.random(),
+            Math.random(),
+            Math.random()
+          ])
+        )
+      )
+      .reshape([2, 2, 3])
+    const batchKeys = sm
+      .tensor(
+        new Float32Array(
+          [0, 1, 0.25, 0, 0.5, 1].concat([
+            Math.random(),
+            Math.random(),
+            Math.random(),
+            Math.random(),
+            Math.random(),
+            Math.random()
+          ])
+        )
+      )
+      .reshape([2, 2, 3])
+    const batchValues = sm
+      .tensor(
+        new Float32Array(
+          [1, 0, 0, 0, 1, 0].concat([
+            Math.random(),
+            Math.random(),
+            Math.random(),
+            Math.random(),
+            Math.random(),
+            Math.random()
+          ])
+        )
+      )
+      .reshape([2, 2, 3])
+
+    const singleResult = module(singleQueries, singleKeys, singleValues)
+    const batchResult = module(batchQueries, batchKeys, batchValues)
+    areSameShape(batchResult, batchQueries)
+
+    expectArraysClose(
+      batchResult.index([0, ':', ':']).toFloat32Array(),
+      singleResult.toFloat32Array()
+    )
+    areSameShape(batchResult.index([0, ':', ':']), singleResult)
+  })
+  it('differing shapes are invalid', () => {
+    const module = new sm.module.TransformerDotProductAttention(3)
+
+    const queries = sm.tensor(new Float32Array([0, 0, 1, 0, 1, 0])).reshape([2, 3])
+    const keys = sm.tensor(new Float32Array([0, 1, 0.25])).reshape([1, 3])
+    const values = sm.tensor(new Float32Array([1, 0, 0, 0, 1, 0])).reshape([2, 3])
+
+    expectThrows(() => module(queries, keys, values), new RegExp('should have the same shape'))
+  })
+  it('differing dimensionalities are invalid', () => {
+    const module = new sm.module.TransformerDotProductAttention(3)
+
+    const queries = sm.tensor(new Float32Array([0, 0, 1, 0, 1, 0])).reshape([2, 3])
+    const keys = sm.tensor(new Float32Array([0, 1, 0.25, 0, 0.5, 1])).reshape([2, 3])
+    const values = sm.tensor(new Float32Array([1, 0, 0, 0, 1, 0])).reshape([1, 2, 3])
+
+    expectThrows(() => module(queries, keys, values), new RegExp('should have the same shape'))
+  })
+  it('invalid dimensions', () => {
+    const module = new sm.module.TransformerDotProductAttention(4)
+
+    const queries = sm.tensor(new Float32Array([0, 0, 1, 0, 1, 0])).reshape([2, 3])
+    const keys = sm.tensor(new Float32Array([0, 1, 0.25, 0, 0.5, 1])).reshape([2, 3])
+    const values = sm.tensor(new Float32Array([1, 0, 0, 0, 1, 0])).reshape([2, 3])
+
+    expectThrows(() => module(queries, keys, values), new RegExp('must match module dimensions'))
+  })
+  it('calculates gradient', () => {
+    const module = new sm.module.TransformerDotProductAttention(3)
+
+    const queries = sm
+      .tensor(new Float32Array([0, 0, 1, 0, 1, 0]))
+      .reshape([2, 3])
+      .requireGrad()
+    const keys = sm
+      .tensor(new Float32Array([0, 1, 0.25, 0, 0.5, 1]))
+      .reshape([2, 3])
+      .requireGrad()
+    const values = sm
+      .tensor(new Float32Array([1, 0, 0, 0, 1, 0]))
+      .reshape([2, 3])
+      .requireGrad()
+
+    const result = module(queries, keys, values).sum()
+    result.backward()
+    expect(!!queries.grad).toBe(true)
+    expect(!!keys.grad).toBe(true)
+    expect(!!values.grad).toBe(true)
+  })
+})
+
+describe('TransformerMultiheadAttention', () => {
+  it('single token, single head', () => {
+    const module = new sm.module.TransformerMultiheadAttention(3, 1)
+    const queries = sm.tensor(new Float32Array([0, 0, 1])).reshape([1, 3])
+    const keys = sm.tensor(new Float32Array([0, 0, 0.5])).reshape([1, 3])
+    const values = sm.tensor(new Float32Array([1, 0, 0])).reshape([1, 3])
+
+    const result = module(queries, keys, values)
+    areSameShape(result, queries)
+  })
+  it('single token, single head (attn_dim)', () => {
+    const module = new sm.module.TransformerMultiheadAttention(3, 1, 7)
+    const queries = sm.tensor(new Float32Array([0, 0, 1])).reshape([1, 3])
+    const keys = sm.tensor(new Float32Array([0, 0, 0.5])).reshape([1, 3])
+    const values = sm.tensor(new Float32Array([1, 0, 0])).reshape([1, 3])
+
+    const result = module(queries, keys, values)
+    areSameShape(result, queries)
+  })
+  it('single token, two heads', () => {
+    const module = new sm.module.TransformerMultiheadAttention(6, 2)
+    const queries = sm.tensor(new Float32Array([0, 0, 1, 0, 1, 0])).reshape([1, 6])
+    const keys = sm.tensor(new Float32Array([0, 0, 0.5, 0.25, 1, 0])).reshape([1, 6])
+    const values = sm.tensor(new Float32Array([1, 0, 0, 0, 1, 0])).reshape([1, 6])
+
+    const result = module(queries, keys, values)
+    areSameShape(result, queries)
+  })
+  it('single token, two heads (attn_dim)', () => {
+    const module = new sm.module.TransformerMultiheadAttention(6, 2, 7)
+    const queries = sm.tensor(new Float32Array([0, 0, 1, 0, 1, 0])).reshape([1, 6])
+    const keys = sm.tensor(new Float32Array([0, 0, 0.5, 0.25, 1, 0])).reshape([1, 6])
+    const values = sm.tensor(new Float32Array([1, 0, 0, 0, 1, 0])).reshape([1, 6])
+
+    const result = module(queries, keys, values)
+    areSameShape(result, queries)
+  })
+  it('two tokens, two heads', () => {
+    const module = new sm.module.TransformerMultiheadAttention(6, 2)
+    const queries = sm
+      .tensor(new Float32Array([0, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 1]))
+      .reshape([2, 6])
+    const keys = sm
+      .tensor(new Float32Array([0, 0, 0.5, 0.25, 1, 0, 3, 0, 3, 0, 3, 3]))
+      .reshape([2, 6])
+    const values = sm.tensor(new Float32Array([1, 0, 0, 0, 1, 0, 3, 3, 3, 0, 0, 3])).reshape([2, 6])
+
+    const result = module(queries, keys, values)
+    areSameShape(result, queries)
+  })
+  it('batch samples are independent', () => {
+    const module = new sm.module.TransformerMultiheadAttention(6, 2)
+
+    const singleQueries = sm.tensor(new Float32Array([0, 0, 1, 0, 1, 0])).reshape([1, 6])
+    const singleKeys = sm.tensor(new Float32Array([0, 0, 0.5, 0.25, 1, 0])).reshape([1, 6])
+    const singleValues = sm.tensor(new Float32Array([1, 0, 0, 0, 1, 0])).reshape([1, 6])
+
+    const batchQueries = sm
+      .tensor(
+        new Float32Array(
+          [0, 0, 1, 0, 1, 0].concat([
+            Math.random(),
+            Math.random(),
+            Math.random(),
+            Math.random(),
+            Math.random(),
+            Math.random()
+          ])
+        )
+      )
+      .reshape([2, 1, 6])
+    const batchKeys = sm
+      .tensor(
+        new Float32Array(
+          [0, 0, 0.5, 0.25, 1, 0].concat([
+            Math.random(),
+            Math.random(),
+            Math.random(),
+            Math.random(),
+            Math.random(),
+            Math.random()
+          ])
+        )
+      )
+      .reshape([2, 1, 6])
+    const batchValues = sm
+      .tensor(
+        new Float32Array(
+          [1, 0, 0, 0, 1, 0].concat([
+            Math.random(),
+            Math.random(),
+            Math.random(),
+            Math.random(),
+            Math.random(),
+            Math.random()
+          ])
+        )
+      )
+      .reshape([2, 1, 6])
+
+    const singleResult = module(singleQueries, singleKeys, singleValues)
+    const batchResult = module(batchQueries, batchKeys, batchValues)
+    areSameShape(batchResult, batchQueries)
+
+    expectArraysClose(
+      batchResult.index([0, ':', ':']).toFloat32Array(),
+      singleResult.toFloat32Array()
+    )
+    areSameShape(batchResult.index([0, ':', ':']), singleResult)
+  })
+  it('indivisible dimension is invalid', () => {
+    expectThrows(
+      () => new sm.module.TransformerMultiheadAttention(5, 2),
+      new RegExp('must be divisible by the number of heads')
+    )
+  })
+  it('differing shapes are invalid', () => {
+    const module = new sm.module.TransformerMultiheadAttention(6, 2)
+    const queries = sm
+      .tensor(new Float32Array([0, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 1]))
+      .reshape([2, 6])
+    const keys = sm.tensor(new Float32Array([0, 0, 0.5, 0.25, 1, 0])).reshape([1, 6])
+    const values = sm.tensor(new Float32Array([1, 0, 0, 0, 1, 0, 3, 3, 3, 0, 0, 3])).reshape([2, 6])
+
+    expectThrows(() => module(queries, keys, values), new RegExp('should have the same shape'))
+  })
+  it('differing dimensionalities are invalid', () => {
+    const module = new sm.module.TransformerMultiheadAttention(6, 2)
+    const queries = sm
+      .tensor(new Float32Array([0, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 1]))
+      .reshape([2, 6])
+    const keys = sm
+      .tensor(new Float32Array([0, 0, 0.5, 0.25, 1, 0, 3, 0, 3, 0, 3, 3]))
+      .reshape([1, 2, 6])
+    const values = sm.tensor(new Float32Array([1, 0, 0, 0, 1, 0, 3, 3, 3, 0, 0, 3])).reshape([2, 6])
+
+    expectThrows(() => module(queries, keys, values), new RegExp('should have the same shape'))
+  })
+  it('invalid dimensions', () => {
+    const module = new sm.module.TransformerMultiheadAttention(8, 2)
+    const queries = sm
+      .tensor(new Float32Array([0, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 1]))
+      .reshape([2, 6])
+    const keys = sm
+      .tensor(new Float32Array([0, 0, 0.5, 0.25, 1, 0, 3, 0, 3, 0, 3, 3]))
+      .reshape([2, 6])
+    const values = sm.tensor(new Float32Array([1, 0, 0, 0, 1, 0, 3, 3, 3, 0, 0, 3])).reshape([2, 6])
+
+    expectThrows(() => module(queries, keys, values), new RegExp('must match module dimensions'))
+  })
+  it('calculates gradient', () => {
+    const module = new sm.module.TransformerMultiheadAttention(6, 2)
+    const queries = sm
+      .tensor(new Float32Array([0, 0, 1, 0, 1, 0]))
+      .reshape([1, 6])
+      .requireGrad()
+    const keys = sm
+      .tensor(new Float32Array([0, 0, 0.5, 0.25, 1, 0]))
+      .reshape([1, 6])
+      .requireGrad()
+    const values = sm
+      .tensor(new Float32Array([1, 0, 0, 0, 1, 0]))
+      .reshape([1, 6])
+      .requireGrad()
+
+    const result = module(queries, keys, values).sum()
+    result.backward()
+    expect(!!queries.grad).toBe(true)
+    expect(!!keys.grad).toBe(true)
+    expect(!!values.grad).toBe(true)
+  })
+})


### PR DESCRIPTION
Added modules for scaled dot-product attention and multi-head attention, to be used as components of a Transformer.

Added a method, `T()`, to Tensor to perform simple transposition of the last two axes only of a Tensor. This operation is used in several places in a Transformer, as well as in the updated gradient function for `matmul` (the previous version of this gradient function only supported 2D Tensors).