### PR TITLE
Fixed gradients of mean and sum

### DIFF
--- a/shumai/tensor/register_gradients.ts
+++ b/shumai/tensor/register_gradients.ts
@@ -10,6 +10,18 @@ export interface Grad {
   out: Tensor
 }
 
+function recoverShape(tensor: Tensor, originalShape: number[], lostAxes: number[]) {
+  const shapeForBroadcast = [...originalShape]
+  for (let axis of lostAxes) {
+    if (axis < 0) {
+      axis += originalShape.length
+    }
+    shapeForBroadcast[axis] = 1
+  }
+  const tensorForBroadcast = tensor.reshape(shapeForBroadcast)
+  return tensorForBroadcast.add(sm.full(originalShape, 0))
+}
+
 function possiblyReduce(grad_out: Tensor, grad: Grad) {
   const input = grad.in[grad.idx]
   const new_shape = input.shape
@@ -117,8 +129,18 @@ const impls = {
     return mask.mul(grad.grad_in)
   },
   mean: (grad: Grad) => {
-    const num = sm.scalar(grad.in[0].elements)
-    return grad.grad_in.tile(grad.in[0].shape).div(num)
+    const inShape = (grad.in[0] as Tensor).shape
+    let axes: number[] = grad.in[1]
+    if (axes.length === 0) {
+      axes = inShape.map((x, i) => i) // All axes
+    }
+
+    let num = 1
+    for (const axis of axes) {
+      num *= inShape[axis]
+    }
+
+    return recoverShape(grad.grad_in.div(sm.scalar(num)), inShape, axes)
   },
   mul: (grad: Grad) => {
     return possiblyReduce(grad.in[1 - grad.idx].mul(grad.grad_in), grad)
@@ -134,7 +156,12 @@ const impls = {
     return possiblyReduce(grad.grad_in, grad)
   },
   sum: (grad: Grad) => {
-    return grad.grad_in.tile(grad.in[0].shape)
+    const inShape = (grad.in[0] as Tensor).shape
+    let axes: number[] = grad.in[1]
+    if (axes.length === 0) {
+      axes = inShape.map((x, i) => i) // All axes
+    }
+    return recoverShape(grad.grad_in, inShape, axes)
   },
   tanh: (grad: Grad) => {
     return sm.scalar(1).sub(grad.out.mul(grad.out))

--- a/shumai/tensor/register_gradients.ts
+++ b/shumai/tensor/register_gradients.ts
@@ -148,13 +148,7 @@ const impls = {
     const range = grad.out.shape.map((x, i) => ':')
     range[axis] = start + ':' + end
 
-    // Expand input gradient tensor to match the shape of the forward output tensor
-    let backwardGradient = grad.grad_in
-    if (grad.grad_in.shape.length < grad.out.shape.length) {
-      backwardGradient = grad.grad_in.add(sm.full(grad.out.shape, 0))
-    }
-
-    return backwardGradient.index(range)
+    return grad.grad_in.index(range)
   }
 }
 

--- a/shumai/tensor/tensor.ts
+++ b/shumai/tensor/tensor.ts
@@ -168,6 +168,9 @@ async function async_traverse_gradients(sorted_traversal, jacobian) {
 // dependencies with requires_grad === True
 export function backward(base_t: Tensor, jacobian: Tensor) {
   if (!jacobian) {
+    if (base_t.elements !== 1) {
+      throw new Error(`Gradient can only be implicitly created for a scalar`)
+    }
     jacobian = full([], 1)
     jacobian.requires_stats = base_t.requires_stats
   }

--- a/shumai/tensor/tensor.ts
+++ b/shumai/tensor/tensor.ts
@@ -89,7 +89,10 @@ export function scalar(s: number): Tensor {
   return full([], s)
 }
 
-function traverse_gradients(sorted_traversal, jacobian) {
+function traverse_gradients(
+  sorted_traversal: Tensor[],
+  jacobian: Tensor
+): Record<number, [Tensor, Tensor]> {
   const all_grads_dict: Record<number, [Tensor, Tensor]> = {}
   const base_t = sorted_traversal[0]
   all_grads_dict[base_t.ptr] = [base_t, jacobian]
@@ -112,10 +115,13 @@ function traverse_gradients(sorted_traversal, jacobian) {
         out: t,
         grad_in: all_grads_dict[t.ptr][1]
       }
-      const g = gradient_functions[t.op](grad_arg)
+      const g: Tensor = gradient_functions[t.op](grad_arg)
       if (dep.ptr in all_grads_dict) {
-        const [t, prev_g] = all_grads_dict[dep.ptr]
-        all_grads_dict[dep.ptr] = [t, prev_g.add(g)]
+        const [prev_dep, prev_g] = all_grads_dict[dep.ptr]
+        if (dep !== prev_dep) {
+          throw new Error(`Internal error: invalid all_grads_dict`)
+        }
+        all_grads_dict[dep.ptr] = [prev_dep, prev_g.add(g)]
       } else {
         all_grads_dict[dep.ptr] = [dep, g]
       }
@@ -124,7 +130,10 @@ function traverse_gradients(sorted_traversal, jacobian) {
   return all_grads_dict
 }
 
-async function async_traverse_gradients(sorted_traversal, jacobian) {
+async function async_traverse_gradients(
+  sorted_traversal: Tensor[],
+  jacobian: Tensor
+): Promise<Record<number, [Tensor, Tensor]>> {
   const all_grads_dict: Record<number, [Tensor, Tensor]> = {}
   const base_t = sorted_traversal[0]
   all_grads_dict[base_t.ptr] = [base_t, jacobian]
@@ -166,7 +175,12 @@ async function async_traverse_gradients(sorted_traversal, jacobian) {
 
 // differentiate t with respect to all
 // dependencies with requires_grad === True
-export function backward(base_t: Tensor, jacobian: Tensor) {
+export function backward(
+  base_t: Tensor,
+  jacobian: Tensor
+):
+  | Record<string, { grad: Tensor; tensor: Tensor }>
+  | Promise<Record<string, { grad: Tensor; tensor: Tensor }>> {
   if (!jacobian) {
     if (base_t.elements !== 1) {
       throw new Error(`Gradient can only be implicitly created for a scalar`)
@@ -218,13 +232,15 @@ export function backward(base_t: Tensor, jacobian: Tensor) {
 
   // NB: can't easily embed this in the traverse functions
   // (or else references are stale)
-  const calc_grads = (all_grads_dict) => {
+  const calc_grads = (
+    all_grads_dict: Record<number, [Tensor, Tensor]>
+  ): Record<string, { grad: Tensor; tensor: Tensor }> => {
     const all_grads: Record<string, { grad: Tensor; tensor: Tensor }> = {}
     for (const key in all_grads_dict) {
       const [t, g] = all_grads_dict[key]
       // NB: not really safe in parallel, but convenient for stateful API
       t.grad = g
-      all_grads[t] = {
+      all_grads[t.toString()] = {
         tensor: t,
         grad: g
       }

--- a/shumai/tensor/tensor.ts
+++ b/shumai/tensor/tensor.ts
@@ -370,7 +370,7 @@ export class Tensor {
     if (typeof obj === 'number') {
       obj = [obj]
     }
-    this._injest_ptr(fl.createTensor.native(...arrayArg(obj, FFIType.i64)))
+    this._injest_ptr(fl.createTensor.native(...arrayArg(obj)))
     return
   }
 
@@ -462,8 +462,8 @@ export class Tensor {
     return wrapFLTensor(
       fl._pad.native,
       this.ptr,
-      ...arrayArg(new BigInt64Array(before_), FFIType.i64),
-      ...arrayArg(new BigInt64Array(after_), FFIType.i64)
+      ...arrayArg(new BigInt64Array(before_)),
+      ...arrayArg(new BigInt64Array(after_))
     )
   }
 
@@ -597,9 +597,9 @@ export class Tensor {
     return wrapFLTensor(
       fl._index.native,
       this,
-      ...arrayArg(start, FFIType.i64),
-      ...arrayArg(end, FFIType.i64),
-      ...arrayArg(stride, FFIType.i64)
+      ...arrayArg(start),
+      ...arrayArg(end),
+      ...arrayArg(stride)
     )
   }
 
@@ -609,9 +609,9 @@ export class Tensor {
       fl._indexedAssign.native,
       this,
       t,
-      ...arrayArg(start, FFIType.i64),
-      ...arrayArg(end, FFIType.i64),
-      ...arrayArg(stride, FFIType.i64)
+      ...arrayArg(start),
+      ...arrayArg(end),
+      ...arrayArg(stride)
     )
   }
 

--- a/test/concatenate.test.ts
+++ b/test/concatenate.test.ts
@@ -247,30 +247,10 @@ describe('concatenate', () => {
       .reshape([3, 2])
       .requireGrad()
 
-    const out = sm.concatenate([a, b], 0)
+    const out = sm.concatenate([a, b], 1).sum()
     out.backward()
     const expectedGradShape = [3, 2]
     const expectedGrad = sm.full(expectedGradShape, 1)
-    const expectedGradArray = expectedGrad.toFloat32Array()
-    expectArraysClose(a.grad.toFloat32Array(), expectedGradArray)
-    expectArraysClose(b.grad.toFloat32Array(), expectedGradArray)
-    expect(isShape(a.grad, expectedGradShape)).toBe(true)
-    expect(isShape(b.grad, expectedGradShape)).toBe(true)
-  })
-  it('gradient from mean', () => {
-    const a = sm
-      .tensor(new Float32Array([0, 1, 2, 3, 4, 5]))
-      .reshape([3, 2])
-      .requireGrad()
-    const b = sm
-      .tensor(new Float32Array([10, 11, 12, 13, 14, 15]))
-      .reshape([3, 2])
-      .requireGrad()
-
-    const out = sm.concatenate([a, b], 0).mean()
-    out.backward()
-    const expectedGradShape = [3, 2]
-    const expectedGrad = sm.full(expectedGradShape, 1 / 12)
     const expectedGradArray = expectedGrad.toFloat32Array()
     expectArraysClose(a.grad.toFloat32Array(), expectedGradArray)
     expectArraysClose(b.grad.toFloat32Array(), expectedGradArray)

--- a/test/mean.test.ts
+++ b/test/mean.test.ts
@@ -62,4 +62,44 @@ describe('mean', () => {
     expect(isShape(mean, [])).toBe(true)
     expectArraysClose(mean.toFloat32Array(), [7 / 6])
   })
+  it('gradient', () => {
+    const t = sm
+      .tensor(new Float32Array([1, 2, 3, 0, 0, 1]))
+      .reshape([3, 2])
+      .requireGrad()
+    const result = sm.mean(t)
+    result.backward()
+    expect(isShape(t.grad, t.shape)).toBe(true)
+    expectArraysClose(t.grad.toFloat32Array(), [1 / 6, 1 / 6, 1 / 6, 1 / 6, 1 / 6, 1 / 6])
+  })
+  it('gradient (keepDims = true)', () => {
+    const t = sm
+      .tensor(new Float32Array([1, 2, 3, 0, 0, 1]))
+      .reshape([3, 2])
+      .requireGrad()
+    const result = sm.mean(t, [], true)
+    result.backward()
+    expect(isShape(t.grad, t.shape)).toBe(true)
+    expectArraysClose(t.grad.toFloat32Array(), [1 / 6, 1 / 6, 1 / 6, 1 / 6, 1 / 6, 1 / 6])
+  })
+  it('gradient, axis=[1]', () => {
+    const t = sm
+      .tensor(new Float32Array([1, 2, 3, 0, 0, 1]))
+      .reshape([3, 2])
+      .requireGrad()
+    const result = sm.mean(t, [1]).sum()
+    result.backward()
+    expect(isShape(t.grad, t.shape)).toBe(true)
+    expectArraysClose(t.grad.toFloat32Array(), [1 / 2, 1 / 2, 1 / 2, 1 / 2, 1 / 2, 1 / 2])
+  })
+  it('gradient, axis=[1] (keepDims = true)', () => {
+    const t = sm
+      .tensor(new Float32Array([1, 2, 3, 0, 0, 1]))
+      .reshape([3, 2])
+      .requireGrad()
+    const result = sm.mean(t, [1], true).sum()
+    result.backward()
+    expect(isShape(t.grad, t.shape)).toBe(true)
+    expectArraysClose(t.grad.toFloat32Array(), [1 / 2, 1 / 2, 1 / 2, 1 / 2, 1 / 2, 1 / 2])
+  })
 })

--- a/test/sum.test.ts
+++ b/test/sum.test.ts
@@ -60,5 +60,44 @@ describe('sum', () => {
     expect(isShape(sum, [2, 2, 1])).toBe(true)
     expectArraysClose(sum.toFloat32Array(), [1, 2, 3, 4])
   })
-  /* TODO: unit tests for gradients */
+  it('gradient', () => {
+    const t = sm
+      .tensor(new Float32Array([1, 2, 3, 0, 0, 1]))
+      .reshape([3, 2])
+      .requireGrad()
+    const result = sm.sum(t)
+    result.backward()
+    expect(isShape(t.grad, t.shape)).toBe(true)
+    expectArraysClose(t.grad.toFloat32Array(), [1, 1, 1, 1, 1, 1])
+  })
+  it('gradient (keepDims = true)', () => {
+    const t = sm
+      .tensor(new Float32Array([1, 2, 3, 0, 0, 1]))
+      .reshape([3, 2])
+      .requireGrad()
+    const result = sm.sum(t, [], true)
+    result.backward()
+    expect(isShape(t.grad, t.shape)).toBe(true)
+    expectArraysClose(t.grad.toFloat32Array(), [1, 1, 1, 1, 1, 1])
+  })
+  it('gradient, axis=[1]', () => {
+    const t = sm
+      .tensor(new Float32Array([1, 2, 3, 0, 0, 1]))
+      .reshape([3, 2])
+      .requireGrad()
+    const result = sm.sum(t, [1]).mean()
+    result.backward()
+    expect(isShape(t.grad, t.shape)).toBe(true)
+    expectArraysClose(t.grad.toFloat32Array(), [1 / 3, 1 / 3, 1 / 3, 1 / 3, 1 / 3, 1 / 3])
+  })
+  it('gradient, axis=[1] (keepDims = true)', () => {
+    const t = sm
+      .tensor(new Float32Array([1, 2, 3, 0, 0, 1]))
+      .reshape([3, 2])
+      .requireGrad()
+    const result = sm.sum(t, [1], true).mean()
+    result.backward()
+    expect(isShape(t.grad, t.shape)).toBe(true)
+    expectArraysClose(t.grad.toFloat32Array(), [1 / 3, 1 / 3, 1 / 3, 1 / 3, 1 / 3, 1 / 3])
+  })
 })


### PR DESCRIPTION
Previously, these gradient functions assumed that the forward function was applied over all axes, and simply tiled the `grad_in` to the same shape as the forward input Tensor. This breaks when the forward function was applied over only a subset of axes, whereupon `grad_in` would not be a scalar and would have the wrong shape when tiled.

This fix was needed in order for the gradients of Transformer-related modules (#78) to behave correctly. This also fixes #74.

Changed `traverse_gradients` and `async_traverse_gradients` to throw an error when `tensor.backward()` is invoked on a non-scalar Tensor. This matches the behaviour in PyTorch. Fixed the gradient and tests of `sm.concatenate` to correctly reflect this behaviour.