### PR TITLE
remove FFIType when calling `arrayArg` and remove import

### DIFF
--- a/scripts/gen_binding.py
+++ b/scripts/gen_binding.py
@@ -589,7 +589,6 @@ if sys.argv[1] in ["js", "js_methods"]:
         # js_methods
         full_js = f"""\
 /* GENERATED CODE (gen_binding.py) */
-import {{ FFIType }} from 'bun:ffi'
 import {{ arrayArg }} from '../ffi/ffi_bind_utils'
 import {{ fl }} from '../ffi/ffi_flashlight'
 import {{ getStack, collectStats }} from './stats'
@@ -604,7 +603,6 @@ export const gen_tensor_op_shim = (_Tensor: new (...args: unknown[]) => Tensor) 
         # js
         full_js = f"""\
 /* GENERATED CODE (gen_binding.py) */
-import {{ FFIType }} from "bun:ffi"
 import {{ arrayArg }} from "../ffi/ffi_bind_utils"
 import {{ fl }} from "../ffi/ffi_flashlight"
 import {{ getStack, collectStats }} from './stats'

--- a/shumai/tensor/tensor.ts
+++ b/shumai/tensor/tensor.ts
@@ -1,4 +1,4 @@
-import { ptr, toArrayBuffer, FFIType } from 'bun:ffi'
+import { ptr, toArrayBuffer } from 'bun:ffi'
 import { fl } from '../ffi/ffi_flashlight'
 import { arrayArg } from '../ffi/ffi_bind_utils'
 import { TensorOpsInterface } from './tensor_ops_interface_gen'
@@ -351,7 +351,7 @@ export class Tensor {
     if (typeof obj === 'number') {
       obj = [obj]
     }
-    this._injest_ptr(fl.createTensor.native(...arrayArg(obj, FFIType.i64)))
+    this._injest_ptr(fl.createTensor.native(...arrayArg(obj)))
     return
   }
 
@@ -443,8 +443,8 @@ export class Tensor {
     return wrapFLTensor(
       fl._pad.native,
       this.ptr,
-      ...arrayArg(new BigInt64Array(before_), FFIType.i64),
-      ...arrayArg(new BigInt64Array(after_), FFIType.i64)
+      ...arrayArg(new BigInt64Array(before_)),
+      ...arrayArg(new BigInt64Array(after_))
     )
   }
 
@@ -558,7 +558,7 @@ export class Tensor {
             end_idx = parseInt(tokens[1])
           }
         }
-        if (tokens.length >= 3 || start_idx === NaN || end_idx === NaN) {
+        if (tokens.length >= 3 || Number.isNaN(start_idx) || Number.isNaN(end_idx)) {
           throw `${arg} not yet supported.  Please file a bug with desired behavior!`
         }
         start.push(start_idx)
@@ -578,9 +578,9 @@ export class Tensor {
     return wrapFLTensor(
       fl._index.native,
       this,
-      ...arrayArg(start, FFIType.i64),
-      ...arrayArg(end, FFIType.i64),
-      ...arrayArg(stride, FFIType.i64)
+      ...arrayArg(start),
+      ...arrayArg(end),
+      ...arrayArg(stride)
     )
   }
 
@@ -590,9 +590,9 @@ export class Tensor {
       fl._indexedAssign.native,
       this,
       t,
-      ...arrayArg(start, FFIType.i64),
-      ...arrayArg(end, FFIType.i64),
-      ...arrayArg(stride, FFIType.i64)
+      ...arrayArg(start),
+      ...arrayArg(end),
+      ...arrayArg(stride)
     )
   }
 

--- a/shumai/tensor/tensor_ops_gen.ts
+++ b/shumai/tensor/tensor_ops_gen.ts
@@ -1,5 +1,4 @@
 /* GENERATED CODE (gen_binding.py) */
-import { FFIType } from 'bun:ffi'
 import { arrayArg } from '../ffi/ffi_bind_utils'
 import { fl } from '../ffi/ffi_flashlight'
 import { getStack, collectStats } from './stats'

--- a/shumai/tensor/tensor_ops_shim_gen.ts
+++ b/shumai/tensor/tensor_ops_shim_gen.ts
@@ -1,5 +1,4 @@
 /* GENERATED CODE (gen_binding.py) */
-import { FFIType } from 'bun:ffi'
 import { arrayArg } from '../ffi/ffi_bind_utils'
 import { fl } from '../ffi/ffi_flashlight'
 import { getStack, collectStats } from './stats'


### PR DESCRIPTION
Were a good number of instances where we were still passing `FFIType` to `arrayArg` as a parameter that I have fixed; additionally, you can't compare `x === NaN` in javascript ([weird lang quirk](https://www.loginradius.com/blog/engineering/checking-for-nan-in-javascript/)), so fixed that as well.