### PR TITLE
Gradient for transpose and reshape

### DIFF
--- a/shumai/tensor/register_gradients.ts
+++ b/shumai/tensor/register_gradients.ts
@@ -184,6 +184,10 @@ const impls = {
       reverseAxes[forwardAxes[i]] = i
     } // If forwardAxes === [], reverseAxes === []
     return grad.grad_in.transpose(reverseAxes)
+  },
+  reshape: (grad: Grad): Tensor => {
+    const inShape = (grad.in[0] as Tensor).shape
+    return grad.grad_in.reshape(inShape)
   }
 }
 

--- a/shumai/tensor/register_gradients.ts
+++ b/shumai/tensor/register_gradients.ts
@@ -176,6 +176,14 @@ const impls = {
     range[axis] = start + ':' + end
 
     return grad.grad_in.index(range)
+  },
+  transpose: (grad: Grad): Tensor => {
+    const forwardAxes = grad.in[1] as number[]
+    const reverseAxes = [...forwardAxes]
+    for (let i = 0; i < forwardAxes.length; i++) {
+      reverseAxes[forwardAxes[i]] = i
+    } // If forwardAxes === [], reverseAxes === []
+    return grad.grad_in.transpose(reverseAxes)
   }
 }
 

--- a/test/basic_ops.test.ts
+++ b/test/basic_ops.test.ts
@@ -1,12 +1,23 @@
 import * as sm from '@shumai/shumai'
 import { it, expect, describe } from 'bun:test'
-import { areSameShape, expectArraysClose } from './utils'
+import { areSameShape, expectArraysClose, isShape } from './utils'
 
 describe('ops', () => {
   it('should reshape', () => {
     const a = sm.tensor(new Float32Array([1, 2, 3, 4])).reshape([2, 2])
     const b = sm.tensor(new Float32Array([1, 2, 3, 4])).reshape([2, 2])
     expect(areSameShape(a, b)).toBe(true)
+  })
+  it('should reshape with gradient', () => {
+    const tensor = sm.tensor(new Float32Array([1, 2, 3, 4])).requireGrad()
+    expect(isShape(tensor, [4])).toBe(true)
+    const reshaped = tensor.reshape([2, 2])
+    const final = reshaped.sum()
+    final.backward()
+    expect(isShape(reshaped.grad, [2, 2])).toBe(true)
+    expectArraysClose(reshaped.grad.toFloat32Array(), [1, 1, 1, 1])
+    expect(isShape(tensor.grad, [4])).toBe(true)
+    expectArraysClose(tensor.grad.toFloat32Array(), [1, 1, 1, 1])
   })
   it('should work for negative', () => {
     const a = sm.tensor(new Float32Array([1, -3, 2, 7, -4]))

--- a/test/transpose.test.ts
+++ b/test/transpose.test.ts
@@ -155,5 +155,36 @@ describe('transpose', () => {
       )
     })
   */
-  /* TODO: unit tests for gradients */
+  it('gradient', () => {
+    const t = sm
+      .tensor(new Float32Array([1, 11, 2, 22, 3, 33, 4, 44]))
+      .reshape([2, 4])
+      .requireGrad()
+    const gradProduct = sm.tensor(new Float32Array([2, 3]))
+    const result = t.transpose([1, 0]).mul(gradProduct).sum()
+    result.backward()
+    expect(isShape(t.grad, [2, 4])).toBe(true)
+    expectArraysClose(t.grad.toFloat32Array(), [2, 2, 2, 2, 3, 3, 3, 3])
+  })
+  it('gradient (no change)', () => {
+    const t = sm
+      .tensor(new Float32Array([1, 11, 2, 22, 3, 33, 4, 44]))
+      .reshape([2, 4])
+      .requireGrad()
+    const gradProduct = sm.tensor(new Float32Array([2, 3, 4, 5]))
+    const result = t.transpose([0, 1]).mul(gradProduct).sum()
+    result.backward()
+    expect(isShape(t.grad, [2, 4])).toBe(true)
+    expectArraysClose(t.grad.toFloat32Array(), [2, 3, 4, 5, 2, 3, 4, 5])
+  })
+  it('gradient; shape has ones', () => {
+    const t = sm
+      .tensor(new Float32Array([1, 2, 3, 4]))
+      .reshape([1, 4])
+      .requireGrad()
+    const result = t.transpose([1, 0]).sum()
+    result.backward()
+    expect(isShape(t.grad, [1, 4])).toBe(true)
+    expectArraysClose(t.grad.toFloat32Array(), [1, 1, 1, 1])
+  })
 })


### PR DESCRIPTION
Added gradient functions for `sm.transpose` and `sm.reshape`, along with tests.