### PR TITLE
Add Min. `clang-format` Version to `CONTRIBUTING.md`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,3 +6,9 @@ Typescript and Javascript files are formatted using Prettier/ESLint; please use 
 bun format
 black $(find . -name "*.py")
 ```
+
+When working on the generated code and executing `bash scripts/gen_all_binding.sh`, the script internally calls the above as well as `clang-format` (>=v14.0.0) for C++ files
+
+```
+clang-format -i shumai/cpp/binding_gen.inl shumai/cpp/flashlight_binding.cc
+```


### PR DESCRIPTION
Per #82, added info regarding minimum required version of `clang-format` (seems to be required `clang-format` >= `v14.0.0`) to the instructions for new contributors to make getting setup a bit easier. 