### PR TITLE
Clean Up Types/Fix Transpositional Errors in `register_gradients.ts`

### DIFF
--- a/examples/distributed/data.ts
+++ b/examples/distributed/data.ts
@@ -9,7 +9,7 @@ const model_ref = (t) => {
 const url = '0.0.0.0:3000'
 const model = sm.io.remote_model(url)
 
-let loss = null
+let loss: sm.Tensor = null
 const loss_print = () => {
   if (loss) {
     return ` ${loss.toFloat32()}`
@@ -28,4 +28,5 @@ for (const _ of sm.util.viter(10000, loss_print)) {
 }
 
 const res = await fetch(`${url}/statistics`)
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const stat = await res.json()

--- a/examples/distributed/differentiate_through_remote_model.ts
+++ b/examples/distributed/differentiate_through_remote_model.ts
@@ -5,7 +5,7 @@ const model = sm.io.remote_model('0.0.0.0:3000')
 
 const val = sm.scalar(1).requireGrad()
 
-for (const i of sm.util.range(300)) {
+for (const _i of sm.util.range(300)) {
   const input = sm.randn([1])
   const out_ref = input.mul(sm.scalar(2))
   const out = await model(input.mul(val))

--- a/examples/python_comparison/serde.ts
+++ b/examples/python_comparison/serde.ts
@@ -2,9 +2,9 @@ import * as sm from '@shumai/shumai'
 
 const t0 = performance.now()
 const x = sm.randn([8, 128, 128])
-for (const i of sm.util.viter(1000)) {
+for (const _i of sm.util.viter(1000)) {
   x.save('/tmp/tensor.sm')
-  const y = sm.tensor('/tmp/tensor.sm')
+  const _y = sm.tensor('/tmp/tensor.sm')
 }
 const t1 = performance.now()
 console.log((t1 - t0) / 1e3)

--- a/shumai/ffi/ffi_bind_utils.ts
+++ b/shumai/ffi/ffi_bind_utils.ts
@@ -1,4 +1,4 @@
-import { ptr, FFIType } from 'bun:ffi'
+import { ptr } from 'bun:ffi'
 import { Tensor } from '@shumai/shumai'
 
 function arrayArg(arg: number | number[] | Tensor[] | BigInt64Array) {

--- a/shumai/io/network.ts
+++ b/shumai/io/network.ts
@@ -111,7 +111,7 @@ export async function tfetch(
   const response = await (() => {
     if (tensor) {
       if (!tensor.provenance) {
-        tensor.provenance = _unique_id
+        tensor.provenance = id
       }
       return fetch(url, {
         method: 'POST',
@@ -249,7 +249,10 @@ export type RouteStats = {
  * @param request_dict - A map of endpoint names to the underlying (possibly async) function calls.
  * @param options - A set of options passed to the underlying Bun.serve call.
  */
-export function serve(request_dict: Record<string, any>, options: ServeOpts) {
+export function serve(
+  request_dict: Record<string, (...args: unknown[]) => Promise<unknown> | unknown | void>,
+  options: ServeOpts
+) {
   const user_data = {}
   const statistics: Record<string, RouteStats> = {}
   const op_stats: TensorOpStats = {}
@@ -272,7 +275,10 @@ export function serve(request_dict: Record<string, any>, options: ServeOpts) {
   }
 
   /* TODO: specify a better type than any as its a function */
-  const serve_request = async (req: Request, fn: any) => {
+  const serve_request = async (
+    req: Request,
+    fn: (...args: unknown[]) => Promise<unknown> | unknown | void
+  ) => {
     const buf = await req.arrayBuffer()
     let ret = null
     if (buf.byteLength) {
@@ -382,7 +388,7 @@ export function serve_model(
   grad_update: OptimizerFn,
   options: ServeOpts,
   // TODO: pending further type refinement (requires a fn; same comments above)
-  req_map: Record<string, (...args: any[]) => any | Promise<any>>
+  req_map: Record<string, (...args: unknown[]) => Promise<unknown> | unknown | void>
 ) {
   const base_req_map = {
     /* TODO: Refine type of param `u` */

--- a/shumai/module/module.ts
+++ b/shumai/module/module.ts
@@ -8,7 +8,8 @@ export class Module extends Function {
     return self
   }
 
-  forward(...args: any[]): Tensor[] | Tensor {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  forward(...args: unknown[]): Tensor[] | Tensor {
     throw new Error('You must implement a `forward()` method in your module')
   }
 }

--- a/shumai/optim/sgd.ts
+++ b/shumai/optim/sgd.ts
@@ -5,7 +5,7 @@ export function sgd(
   learning_rate = 1e-3
 ) {
   const lr = sm.scalar(-learning_rate)
-  for (const [k, v] of Object.entries(grads)) {
+  for (const [, v] of Object.entries(grads)) {
     const { tensor: t, grad: g } = v
     if (t.requires_grad) {
       t.update(t.detach().add(g.detach().mul(lr)))

--- a/shumai/tensor/tensor.ts
+++ b/shumai/tensor/tensor.ts
@@ -7,6 +7,7 @@ import { gen_tensor_op_shim } from './tensor_ops_shim_gen'
 import * as ops from './tensor_ops'
 import { getStack, collectStats } from './stats'
 import type { OpStats } from '../io'
+import { Grad } from './register_gradients'
 export { NATIVE_FILE } from '../ffi/ffi_flashlight'
 
 fl.init.native()
@@ -150,7 +151,7 @@ async function async_traverse_gradients(
       if (!dep.requires_grad) {
         continue
       }
-      const grad_arg = {
+      const grad_arg = <Grad>{
         idx: idx,
         in: t.deps,
         out: t,
@@ -267,7 +268,7 @@ export class Tensor {
   grad: Tensor = null
   op = 'constant'
 
-  grad_callback_async?: (grad?: any) => Promise<void | Tensor>
+  grad_callback_async?: (grad?: Grad) => Promise<void | Tensor>
 
   /** @private */
   _injest_ptr(_ptr) {
@@ -561,7 +562,7 @@ export class Tensor {
     const stride = []
     for (const arg of args) {
       if (typeof arg === 'string') {
-        const tokens = arg.split(':').map((x, i) => x.trim())
+        const tokens = arg.split(':').map((x) => x.trim())
         let start_idx = -1
         let end_idx = -1
         if (tokens.length >= 1) {

--- a/shumai/util/async.ts
+++ b/shumai/util/async.ts
@@ -20,6 +20,7 @@ export function sleep(ms: number) {
  * ```
  *
  * */
-export function all(...args: Promise<any>[]) {
-  return Promise.all(args)
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function all<T extends any[]>(...args: Promise<T[number]>[]): Promise<Awaited<T>[]> {
+  return Promise.all<T>(args)
 }

--- a/test/concatenate.test.ts
+++ b/test/concatenate.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'bun:test'
 import * as sm from '@shumai/shumai'
-import { expectArraysClose, expectThrows, nativeError, isClose, isShape } from './utils'
+import { expectArraysClose, expectThrows, nativeError, isShape } from './utils'
 
 describe('concatenate', () => {
   it('scalar tensors invalid dims', () => {


### PR DESCRIPTION
Major type cleanup; believe we went from ~24 ESLint warnings to 2 ESLint warnings after this change (the latter 2 warnings are pending further refinement on network API as we'll be able to replace `any` with a more specific type at that point). 