### PR TITLE
Added aliases to tensor_ops_interface_gen to match tensor_ops_gen

### DIFF
--- a/scripts/gen_binding.py
+++ b/scripts/gen_binding.py
@@ -209,7 +209,8 @@ op_aliases = {
   "greaterThan": ["gt"],
   "greaterThanEqual": ["gte"],
   "var": ["variance"],
-  "norm": ["normalize"]
+  "norm": ["normalize"],
+  "concatenate": ["concat"],
 }
 
 # ops that need inputs transposed to work correctly

--- a/scripts/gen_binding.py
+++ b/scripts/gen_binding.py
@@ -566,7 +566,10 @@ for op, args, ret in op_list:
     if supports_method:
         if op in comments:
             full_js_types.append(comments[op][1])
-        full_js_types.append(f"  {op}({', '.join(ts_sig[1:])}) : {to_ts[ret]};")
+        full_js_types.append(f"  {valid_js(op)}({', '.join(ts_sig[1:])}) : {to_ts[ret]};")
+        if op in op_aliases:
+            for alias in op_aliases[op]:
+                full_js_types.append(f"  {valid_js(alias)}({', '.join(ts_sig[1:])}) : {to_ts[ret]};")
     full_ffi.append(ffi)
     full_c.append(c)
 

--- a/shumai/tensor/tensor_ops_gen.ts
+++ b/shumai/tensor/tensor_ops_gen.ts
@@ -600,6 +600,10 @@ export function concatenate(tensors: Array<Tensor>, axis: number) {
   return t
 }
 
+export function concat(tensors: Array<Tensor>, axis: number) {
+  return concatenate(tensors, axis)
+}
+
 /**
  *
  *   Determine the indices of elements that are non-zero. There is a method version of this static function: {@link Tensor.nonzero | Tensor.nonzero }.

--- a/shumai/tensor/tensor_ops_interface_gen.ts
+++ b/shumai/tensor/tensor_ops_interface_gen.ts
@@ -108,6 +108,7 @@ interface TensorOpsInterface {
    *   @returns - A new {@link Tensor}
    */
   negative(): Tensor
+  negate(): Tensor
   /**
    *
    *   Take the logical `not` of every element in a tensor. There is a static function version of this method: {@link logicalNot}.
@@ -343,6 +344,7 @@ interface TensorOpsInterface {
    *   @returns - A new {@link Tensor}
    */
   absolute(): Tensor
+  abs(): Tensor
   /**
    *
    *   Calculate the sigmoid (logistic function) for each element in a {@link Tensor}. There is a static function version of this method: {@link sigmoid}.
@@ -398,9 +400,13 @@ interface TensorOpsInterface {
   eq(other: Tensor): Tensor
   neq(other: Tensor): Tensor
   lessThan(other: Tensor): Tensor
+  lt(other: Tensor): Tensor
   lessThanEqual(other: Tensor): Tensor
+  lte(other: Tensor): Tensor
   greaterThan(other: Tensor): Tensor
+  gt(other: Tensor): Tensor
   greaterThanEqual(other: Tensor): Tensor
+  gte(other: Tensor): Tensor
   logicalOr(other: Tensor): Tensor
   logicalAnd(other: Tensor): Tensor
   mod(other: Tensor): Tensor
@@ -413,6 +419,7 @@ interface TensorOpsInterface {
   maximum(other: Tensor): Tensor
   power(other: Tensor): Tensor
   matmul(other: Tensor): Tensor
+  mm(other: Tensor): Tensor
   conv2d(
     weights: Tensor,
     sx?: number,
@@ -431,9 +438,11 @@ interface TensorOpsInterface {
   cumsum(axis: number): Tensor
   mean(axes?: BigInt64Array | number[], keep_dims?: boolean): Tensor
   median(axes?: BigInt64Array | number[], keep_dims?: boolean): Tensor
-  var(axes?: BigInt64Array | number[], bias?: boolean, keep_dims?: boolean): Tensor
+  _var(axes?: BigInt64Array | number[], bias?: boolean, keep_dims?: boolean): Tensor
+  variance(axes?: BigInt64Array | number[], bias?: boolean, keep_dims?: boolean): Tensor
   std(axes?: BigInt64Array | number[], keep_dims?: boolean): Tensor
   norm(axes?: BigInt64Array | number[], p?: number, keep_dims?: boolean): Tensor
+  normalize(axes?: BigInt64Array | number[], p?: number, keep_dims?: boolean): Tensor
   countNonzero(axes?: BigInt64Array | number[], keep_dims?: boolean): Tensor
   any(axes?: BigInt64Array | number[], keep_dims?: boolean): Tensor
   all(axes?: BigInt64Array | number[], keep_dims?: boolean): Tensor


### PR DESCRIPTION
Also applied `valid_js` to the interface ops as well.

Previously the interface methods generated were slightly out of sync with the actual shim methods (discovered this why trying to use `tensor.var()`).