### PR TITLE
fix `valueOf` to automatically return based on dtype

### DIFF
--- a/shumai/cpp/flashlight_binding.cc
+++ b/shumai/cpp/flashlight_binding.cc
@@ -549,61 +549,61 @@ unsigned* _uint64Buffer(void* t) {
 float _float32Scalar(void* t) {
   LOCK_GUARD
   auto* tensor = reinterpret_cast<fl::Tensor*>(t);
-  return tensor->scalar<float>();
+  return tensor->asScalar<float>();
 }
 
 float _float64Scalar(void* t) {
   LOCK_GUARD
   auto* tensor = reinterpret_cast<fl::Tensor*>(t);
-  return tensor->scalar<float>();
+  return tensor->asScalar<float>();
 }
 
 char _boolInt8Scalar(void* t) {
   LOCK_GUARD
   auto* tensor = reinterpret_cast<fl::Tensor*>(t);
-  return tensor->scalar<char>();
+  return tensor->asScalar<char>();
 }
 
 int16_t _int16Scalar(void* t) {
   LOCK_GUARD
   auto* tensor = reinterpret_cast<fl::Tensor*>(t);
-  return tensor->scalar<int16_t>();
+  return tensor->asScalar<int16_t>();
 }
 
 int32_t _int32Scalar(void* t) {
   LOCK_GUARD
   auto* tensor = reinterpret_cast<fl::Tensor*>(t);
-  return tensor->scalar<int32_t>();
+  return tensor->asScalar<int32_t>();
 }
 
 int64_t _int64Scalar(void* t) {
   LOCK_GUARD
   auto* tensor = reinterpret_cast<fl::Tensor*>(t);
-  return tensor->scalar<int64_t>();
+  return tensor->asScalar<int64_t>();
 }
 
 uint8_t _uint8Scalar(void* t) {
   LOCK_GUARD
   auto* tensor = reinterpret_cast<fl::Tensor*>(t);
-  return tensor->scalar<uint8_t>();
+  return tensor->asScalar<uint8_t>();
 }
 
 uint16_t _uint16Scalar(void* t) {
   LOCK_GUARD
   auto* tensor = reinterpret_cast<fl::Tensor*>(t);
-  return tensor->scalar<uint16_t>();
+  return tensor->asScalar<uint16_t>();
 }
 
 uint32_t _uint32Scalar(void* t) {
   LOCK_GUARD
   auto* tensor = reinterpret_cast<fl::Tensor*>(t);
-  return tensor->scalar<uint32_t>();
+  return tensor->asScalar<uint32_t>();
 }
 
 uint64_t _uint64Scalar(void* t) {
   LOCK_GUARD
   auto* tensor = reinterpret_cast<fl::Tensor*>(t);
-  return tensor->scalar<uint64_t>();
+  return tensor->asScalar<uint64_t>();
 }
 
 void* _index(void* t,

--- a/shumai/cpp/flashlight_binding.cc
+++ b/shumai/cpp/flashlight_binding.cc
@@ -450,6 +450,18 @@ float* _float64Buffer(void* t) {
   }
 }
 
+int* _boolInt8Buffer(void* t) {
+  try {
+    LOCK_GUARD
+    auto* tensor = reinterpret_cast<fl::Tensor*>(t);
+    return tensor->astype(fl::dtype::b8).host<int>();
+  } catch (std::exception const& e) {
+    HANDLE_EXCEPTION(e.what());
+  } catch (...) {
+    HANDLE_EXCEPTION("[unknown]");
+  }
+}
+
 int* _int16Buffer(void* t) {
   try {
     LOCK_GUARD
@@ -534,10 +546,64 @@ unsigned* _uint64Buffer(void* t) {
   }
 }
 
-float _scalar(void* t) {
+float _float32Scalar(void* t) {
   LOCK_GUARD
   auto* tensor = reinterpret_cast<fl::Tensor*>(t);
   return tensor->scalar<float>();
+}
+
+float _float64Scalar(void* t) {
+  LOCK_GUARD
+  auto* tensor = reinterpret_cast<fl::Tensor*>(t);
+  return tensor->scalar<float>();
+}
+
+char _boolInt8Scalar(void* t) {
+  LOCK_GUARD
+  auto* tensor = reinterpret_cast<fl::Tensor*>(t);
+  return tensor->scalar<char>();
+}
+
+int16_t _int16Scalar(void* t) {
+  LOCK_GUARD
+  auto* tensor = reinterpret_cast<fl::Tensor*>(t);
+  return tensor->scalar<int16_t>();
+}
+
+int32_t _int32Scalar(void* t) {
+  LOCK_GUARD
+  auto* tensor = reinterpret_cast<fl::Tensor*>(t);
+  return tensor->scalar<int32_t>();
+}
+
+int64_t _int64Scalar(void* t) {
+  LOCK_GUARD
+  auto* tensor = reinterpret_cast<fl::Tensor*>(t);
+  return tensor->scalar<int64_t>();
+}
+
+uint8_t _uint8Scalar(void* t) {
+  LOCK_GUARD
+  auto* tensor = reinterpret_cast<fl::Tensor*>(t);
+  return tensor->scalar<uint8_t>();
+}
+
+uint16_t _uint16Scalar(void* t) {
+  LOCK_GUARD
+  auto* tensor = reinterpret_cast<fl::Tensor*>(t);
+  return tensor->scalar<uint16_t>();
+}
+
+uint32_t _uint32Scalar(void* t) {
+  LOCK_GUARD
+  auto* tensor = reinterpret_cast<fl::Tensor*>(t);
+  return tensor->scalar<uint32_t>();
+}
+
+uint64_t _uint64Scalar(void* t) {
+  LOCK_GUARD
+  auto* tensor = reinterpret_cast<fl::Tensor*>(t);
+  return tensor->scalar<uint64_t>();
 }
 
 void* _index(void* t,

--- a/shumai/ffi/ffi_tensor.ts
+++ b/shumai/ffi/ffi_tensor.ts
@@ -207,9 +207,45 @@ const ffi_tensor = {
     args: [FFIType.ptr],
     returns: FFIType.ptr
   },
-  _scalar: {
+  _float32Scalar: {
     args: [FFIType.ptr],
     returns: FFIType.f32
+  },
+  _float64Scalar: {
+    args: [FFIType.ptr],
+    returns: FFIType.f64
+  },
+  _boolInt8Scalar: {
+    args: [FFIType.ptr],
+    returns: FFIType.i8
+  },
+  _int16Scalar: {
+    args: [FFIType.ptr],
+    returns: FFIType.i16
+  },
+  _int32Scalar: {
+    args: [FFIType.ptr],
+    returns: FFIType.i32
+  },
+  _int64Scalar: {
+    args: [FFIType.ptr],
+    returns: FFIType.i64
+  },
+  _uint8Scalar: {
+    args: [FFIType.ptr],
+    returns: FFIType.u8
+  },
+  _uint16Scalar: {
+    args: [FFIType.ptr],
+    returns: FFIType.u16
+  },
+  _uint32Scalar: {
+    args: [FFIType.ptr],
+    returns: FFIType.u32
+  },
+  _uint64Scalar: {
+    args: [FFIType.ptr],
+    returns: FFIType.u64
   },
   _elements: {
     args: [FFIType.ptr],

--- a/shumai/tensor/tensor.ts
+++ b/shumai/tensor/tensor.ts
@@ -435,10 +435,30 @@ export class Tensor {
   }
 
   valueOf() {
-    if (this.elements == 1) {
-      return this.toFloat32()
+    switch (this.dtype) {
+      case dtype.Float32:
+        return this.elements == 1 ? this.toFloat32() : this.toFloat32Array()
+      case dtype.Float64:
+        return this.elements == 1 ? this.toFloat64() : this.toFloat64Array()
+      case dtype.BoolInt8:
+        return this.elements == 1 ? this.toBoolInt8() : this.toBoolInt8Array()
+      case dtype.Int16:
+        return this.elements == 1 ? this.toInt16() : this.toInt16Array()
+      case dtype.Int32:
+        return this.elements == 1 ? this.toInt32() : this.toInt32Array()
+      case dtype.Int64:
+        return this.elements == 1 ? this.toBigInt64() : this.toBigInt64Array()
+      case dtype.Uint8:
+        return this.elements == 1 ? this.toUint8() : this.toUint8Array()
+      case dtype.Uint16:
+        return this.elements == 1 ? this.toUint16() : this.toUint16Array()
+      case dtype.Uint32:
+        return this.elements == 1 ? this.toUint32() : this.toUint32Array()
+      case dtype.Uint64:
+        return this.elements == 1 ? this.toBigUint64() : this.toBigUint64Array()
+      default:
+        throw new Error(`dtype "${dtype[this.dtype]}" unhandled, please file an issue`)
     }
-    return this.toFloat32Array()
   }
 
   asContiguousTensor() {
@@ -506,6 +526,12 @@ export class Tensor {
     return new Float64Array(toArrayBuffer(fl._float64Buffer.native(contig.ptr), 0, elems * 8))
   }
 
+  toBoolInt8Array() {
+    const contig = this.asContiguousTensor()
+    const elems = contig.elements
+    return new Int8Array(toArrayBuffer(fl._boolInt8Buffer.native(contig.ptr), 0, elems))
+  }
+
   toInt16Array() {
     const contig = this.asContiguousTensor()
     const elems = contig.elements
@@ -549,7 +575,43 @@ export class Tensor {
   }
 
   toFloat32(): number {
-    return fl._scalar.native(this.ptr)
+    return fl._float32Scalar.native(this.ptr)
+  }
+
+  toFloat64(): number {
+    return fl._float64Scalar.native(this.ptr)
+  }
+
+  toBoolInt8(): number {
+    return fl._boolInt8Scalar.native(this.ptr)
+  }
+
+  toInt16(): number {
+    return fl._int16Scalar.native(this.ptr)
+  }
+
+  toInt32(): number {
+    return fl._int32Scalar.native(this.ptr)
+  }
+
+  toBigInt64(): bigint {
+    return fl._int64Scalar.native(this.ptr)
+  }
+
+  toUint8(): number {
+    return fl._uint8Scalar.native(this.ptr)
+  }
+
+  toUint16(): number {
+    return fl._uint16Scalar.native(this.ptr)
+  }
+
+  toUint32(): number {
+    return fl._uint32Scalar.native(this.ptr)
+  }
+
+  toBigUint64(): bigint {
+    return fl._uint64Scalar.native(this.ptr)
   }
 
   /** @private */


### PR DESCRIPTION
Update `valueOf` to automatically handle returning the correct type for JS runtime using switch case on `dtype`. Add native code to handle scalar values. Fixes #86 