### PR TITLE
Get `matmul` gradient, `T`, Linear and LSTM working with 1D tensors

### DIFF
--- a/shumai/module/index.ts
+++ b/shumai/module/index.ts
@@ -1,6 +1,5 @@
 export * from './module'
 export * from './norm'
-
 export * from './linear'
 export * from './lstm'
 export * from './transformer'

--- a/shumai/module/linear.ts
+++ b/shumai/module/linear.ts
@@ -10,7 +10,7 @@ export class Linear extends Module {
   constructor(inp_dim: number, out_dim: number) {
     super()
     this.weight = sm.randn([inp_dim, out_dim])
-    this.bias = sm.randn([1, out_dim])
+    this.bias = sm.randn([out_dim])
     this.weight.requires_grad = true
     this.bias.requires_grad = true
   }

--- a/shumai/module/lstm.ts
+++ b/shumai/module/lstm.ts
@@ -20,16 +20,16 @@ export class LSTM extends Module {
     super()
     this.W_f = sm.randn([inp_dim, out_dim])
     this.U_f = sm.randn([out_dim, out_dim])
-    this.b_f = sm.randn([1, out_dim])
+    this.b_f = sm.randn([out_dim])
     this.W_i = sm.randn([inp_dim, out_dim])
     this.U_i = sm.randn([out_dim, out_dim])
-    this.b_i = sm.randn([1, out_dim])
+    this.b_i = sm.randn([out_dim])
     this.W_o = sm.randn([inp_dim, out_dim])
     this.U_o = sm.randn([out_dim, out_dim])
-    this.b_o = sm.randn([1, out_dim])
+    this.b_o = sm.randn([out_dim])
     this.W_c = sm.randn([inp_dim, out_dim])
     this.U_c = sm.randn([out_dim, out_dim])
-    this.b_c = sm.randn([1, out_dim])
+    this.b_c = sm.randn([out_dim])
   }
 
   forward(x: Tensor, h: Tensor, c: Tensor): [Tensor, Tensor] {

--- a/shumai/module/norm.ts
+++ b/shumai/module/norm.ts
@@ -1,6 +1,5 @@
 import * as ops from '../tensor/tensor_ops'
 import * as tensor from '../tensor/tensor'
-
 import { Module } from './module'
 import type { Tensor } from '../tensor'
 

--- a/shumai/tensor/tensor.ts
+++ b/shumai/tensor/tensor.ts
@@ -677,6 +677,11 @@ export class Tensor {
   }
 
   T(): Tensor {
+    if (this.shape.length === 0) {
+      return this
+    } else if (this.shape.length === 1) {
+      return this.reshape([this.shape[0], 1])
+    }
     const axes = this.shape.map((x, i) => i)
     axes[axes.length - 1] = axes.length - 2
     axes[axes.length - 2] = axes.length - 1

--- a/test/linear.test.ts
+++ b/test/linear.test.ts
@@ -9,6 +9,12 @@ describe('linear', () => {
     const y = l(x)
     expect(isShape(y, [1, 128])).toBe(true)
   })
+  it('single sample', () => {
+    const x = sm.randn([64])
+    const l = sm.module.linear(64, 128)
+    const y = l(x)
+    expect(isShape(y, [128])).toBe(true)
+  })
   it('batch', () => {
     const x = sm.randn([37, 64])
     const l = sm.module.linear(64, 128)
@@ -16,7 +22,15 @@ describe('linear', () => {
     expect(isShape(y, [37, 128])).toBe(true)
   })
   it('gradient', () => {
-    const x = sm.randn([1, 64])
+    const x = sm.randn([2, 64])
+    x.requires_grad = true
+    const l = sm.module.linear(64, 128)
+    const y = l(x)
+    y.sum().backward()
+    expect(!!x.grad).toBe(true)
+  })
+  it('single sample gradient', () => {
+    const x = sm.randn([64])
     x.requires_grad = true
     const l = sm.module.linear(64, 128)
     const y = l(x)


### PR DESCRIPTION
I don't think there is any reason that these modules shouldn't work on single vectors in principle. In practice this mostly makes it easier to use them in test cases.

This should broadcast the single dimension of `bias` to all other axes.

Fixed the gradient of `matmul()` and fixed `T()` to work with 0D and 1D Tensors.