### PR TITLE
implement Float16Array (using Float32Array in JS)

### DIFF
--- a/examples/distributed/data.ts
+++ b/examples/distributed/data.ts
@@ -16,7 +16,7 @@ const loss_print = () => {
   }
 }
 
-for (const _ of sm.util.viter(10000, loss_print)) {
+for (const _ of sm.util.viter(1000000, loss_print)) {
   const input = sm.randn([1, 8])
   input.requires_stats = true
   const out_ref = model_ref(input)

--- a/shumai/cpp/flashlight_binding.cc
+++ b/shumai/cpp/flashlight_binding.cc
@@ -108,6 +108,21 @@ void* createTensor(void* shape_ptr, int64_t shape_len) {
   }
 }
 
+void* tensorFromFloat16Buffer(int64_t numel, void* ptr) {
+  try {
+    LOCK_GUARD
+    auto* t = new fl::Tensor(
+        fl::Tensor::fromBuffer({numel}, (float*)ptr, fl::MemoryLocation::Host)
+            .astype(fl::dtype::f16));
+    g_bytes_used += t->bytes();
+    return t;
+  } catch (std::exception const& e) {
+    HANDLE_EXCEPTION(e.what());
+  } catch (...) {
+    HANDLE_EXCEPTION("[unknown]");
+  }
+}
+
 void* tensorFromFloat32Buffer(int64_t numel, void* ptr) {
   try {
     LOCK_GUARD
@@ -419,7 +434,7 @@ float* _float16Buffer(void* t) {
   try {
     LOCK_GUARD
     auto* tensor = reinterpret_cast<fl::Tensor*>(t);
-    return tensor->astype(fl::dtype::f16).host<float>();
+    return tensor->astype(fl::dtype::f32).host<float>();
   } catch (std::exception const& e) {
     HANDLE_EXCEPTION(e.what());
   } catch (...) {
@@ -545,6 +560,12 @@ unsigned* _uint64Buffer(void* t) {
   } catch (...) {
     HANDLE_EXCEPTION("[unknown]");
   }
+}
+
+float _float16Scalar(void* t) {
+  LOCK_GUARD
+  auto* tensor = reinterpret_cast<fl::Tensor*>(t);
+  return tensor->asScalar<float>();
 }
 
 float _float32Scalar(void* t) {

--- a/shumai/ffi/ffi_tensor.ts
+++ b/shumai/ffi/ffi_tensor.ts
@@ -56,6 +56,10 @@ const ffi_tensor = {
   genTensorDestroyer: {
     returns: FFIType.ptr
   },
+  tensorFromFloat16Buffer: {
+    args: [FFIType.i64, FFIType.ptr],
+    returns: FFIType.ptr
+  },
   tensorFromFloat32Buffer: {
     args: [FFIType.i64, FFIType.ptr],
     returns: FFIType.ptr
@@ -206,6 +210,10 @@ const ffi_tensor = {
   _copy: {
     args: [FFIType.ptr],
     returns: FFIType.ptr
+  },
+  _float16Scalar: {
+    args: [FFIType.ptr],
+    returns: FFIType.float
   },
   _float32Scalar: {
     args: [FFIType.ptr],

--- a/shumai/tensor/tensor.ts
+++ b/shumai/tensor/tensor.ts
@@ -8,6 +8,7 @@ import * as ops from './tensor_ops'
 import { getStack, collectStats } from './stats'
 import type { OpStats } from '../io'
 import { Grad } from './register_gradients'
+import { Float16Array } from '../util'
 export { NATIVE_FILE } from '../ffi/ffi_flashlight'
 
 fl.init.native()
@@ -304,6 +305,12 @@ export class Tensor {
       this._injest_ptr(fl.load(cstr_buffer, cstr_buffer.length))
       return
     }
+    if (obj instanceof Float16Array) {
+      const len_ = obj.length
+      const len = len_.constructor === BigInt ? len_ : BigInt(len_ || 0)
+      this._injest_ptr(fl.tensorFromFloat16Buffer.native(len, ptr(obj)))
+      return
+    }
     if (obj.constructor === Float32Array) {
       const len_ = obj.length
       const len = len_.constructor === BigInt ? len_ : BigInt(len_ || 0)
@@ -434,6 +441,8 @@ export class Tensor {
 
   valueOf() {
     switch (this.dtype) {
+      case dtype.Float16:
+        return this.elements == 1 ? this.toFloat16() : this.toFloat16Array()
       case dtype.Float32:
         return this.elements == 1 ? this.toFloat32() : this.toFloat32Array()
       case dtype.Float64:
@@ -504,13 +513,11 @@ export class Tensor {
     return Number(fl._elements.native(this.ptr))
   }
 
-  /* TODO: https://github.com/facebookresearch/shumai/issues/54
-    toFloat16Array() {
-      const contig = this.asContiguousTensor()
-      const elems = contig.elements
-      return new Float32Array(toArrayBuffer(fl._float16Buffer.native(contig.ptr), 0, elems * 2))
-    }
-  */
+  toFloat16Array() {
+    const contig = this.asContiguousTensor()
+    const elems = contig.elements
+    return new Float16Array(toArrayBuffer(fl._float16Buffer.native(contig.ptr), 0, elems * 4))
+  }
 
   toFloat32Array() {
     const contig = this.asContiguousTensor()
@@ -570,6 +577,10 @@ export class Tensor {
     const contig = this.asContiguousTensor()
     const elems = contig.elements
     return new BigUint64Array(toArrayBuffer(fl._uint64Buffer.native(contig.ptr), 0, elems * 8))
+  }
+
+  toFloat16() {
+    return fl._float16Scalar.native(this.ptr)
   }
 
   toFloat32(): number {

--- a/shumai/util/types.ts
+++ b/shumai/util/types.ts
@@ -10,3 +10,5 @@ export type ArrayLike =
   | Uint32Array
   | BigUint64Array
   | number[]
+
+export class Float16Array extends Float32Array {}

--- a/test/Float16Array.test.ts
+++ b/test/Float16Array.test.ts
@@ -1,0 +1,31 @@
+import { it, describe, expect } from 'bun:test'
+import * as sm from '@shumai/shumai'
+import { expectArraysClose } from './utils'
+
+const { Float16Array } = sm.util
+
+describe('Float16Array', () => {
+  it('basic', () => {
+    let a = sm.scalar(6)
+    a = a.astype(sm.dtype.Float16)
+    expect(a.dtype).toBe(sm.dtype.Float16)
+    expect(a.valueOf()).toBe(6)
+
+    a = sm.tensor(new Float16Array([1, 2, 3, 4, 5, 6, 7, 8]))
+    expect(a.dtype).toBe(sm.dtype.Float16)
+    expectArraysClose(a.valueOf(), [1, 2, 3, 4, 5, 6, 7, 8])
+
+    a = sm.tensor(new Float32Array(new Array(100).fill(Math.random())))
+    expect(a.dtype).toBe(sm.dtype.Float32)
+    const b = a.astype(sm.dtype.Float16)
+    expect(b.dtype).toBe(sm.dtype.Float16)
+    expectArraysClose(a.toFloat16Array(), b.valueOf())
+  })
+
+  it('can be tested using `instanceof`', () => {
+    const og = new Float16Array(new Array(100).fill(Math.random()))
+    expect(og instanceof Float16Array).toBe(true)
+    const a = sm.tensor(og)
+    expect(a.valueOf() instanceof Float16Array).toBe(true)
+  })
+})

--- a/test/activations.test.ts
+++ b/test/activations.test.ts
@@ -1,6 +1,6 @@
-import { it, describe, expect } from 'bun:test'
+import { it, describe } from 'bun:test'
 import * as sm from '@shumai/shumai'
-import { expectArraysClose, isShape } from './utils'
+import { expectArraysClose } from './utils'
 
 describe('activations', () => {
   it('relu negative', () => {


### PR DESCRIPTION
Wrote `Float16Array` helper type, which extends Javascript's `Float32Array`; added matching native code to allow returning data from tensors with `dtype.Float16` to the newly added `Float16Array` polyfill.

Accordingly, have updated the Tensor constructor to check for `instanceof Float16Array` and create a tensor with dtype `dtype.Float16`. The logic in `valueOf` has also been updated to handle dtype `dtype.Float16`.

Tests included to demonstrate usage a bit further.