### PR TITLE
Transformer encoder

### DIFF
--- a/shumai/module/transformer.ts
+++ b/shumai/module/transformer.ts
@@ -9,8 +9,27 @@ import { Sequential } from './sequential'
 
 const sm = { ...ops, ...tensor, util }
 
+/**
+ * A module to generate the positional encoding for a Transformer of a given input dimension,
+ *
+ * $$ \mathrm{PE}_{i, 2z} = \sin \left( \frac{i}{10000^{2z/d}} \right) $$
+ *
+ * $$ \mathrm{PE}_{i, 2z + 1} = \cos \left( \frac{i}{10000^{2z/d}} \right) $$
+ *
+ * where $i$ is the sequence position, $2z$ and $2z+1$ are the dimensions of the input embedding, and $d$ is the dimensionality of the input embedding.
+ *
+ * The multiplicative factors $\frac{1}{10000^{2z/d}}$ are precomputed during object creation as they are constant for all $i$.
+ *
+ * The full PE is initially precomputed for all $i$ up to 256 (configurable). If the module is called with a sequence length larger than the initial value, the additional values are also calculated and stored.
+ */
 export class TransformerPositionalEncoding extends Module {
+  /**
+   * The default `initSequenceLength` if none is supplied in the constructor.
+   */
   static readonly DEFAULT_SEQUENCE_LENGTH = 256
+  /**
+   * The base of the exponent in the positional encoding.
+   */
   static readonly ENCODING_BASE = 10000
 
   private dim: number
@@ -18,7 +37,11 @@ export class TransformerPositionalEncoding extends Module {
   private encodingFactors: Tensor
   private encoding: Tensor
 
-  constructor(dim: number, sequenceLength?: number) {
+  /**
+   * @param dim - Number of dimensions of each input embedding
+   * @param initSequenceLength - Initial sequence length that the positional embedding should be computed for, or {@link DEFAULT_SEQUENCE_LENGTH} if not specified
+   */
+  constructor(dim: number, initSequenceLength?: number) {
     super()
 
     if (dim <= 0) {
@@ -26,12 +49,12 @@ export class TransformerPositionalEncoding extends Module {
     }
 
     this.dim = dim
-    if (sequenceLength === undefined) {
+    if (initSequenceLength === undefined) {
       this.sequenceLength = TransformerPositionalEncoding.DEFAULT_SEQUENCE_LENGTH
-    } else if (sequenceLength <= 0) {
-      throw new Error(`Initial sequenceLength must be > 0: got ${sequenceLength}`)
+    } else if (initSequenceLength <= 0) {
+      throw new Error(`Initial sequenceLength must be > 0: got ${initSequenceLength}`)
     } else {
-      this.sequenceLength = sequenceLength
+      this.sequenceLength = initSequenceLength
     }
 
     // base and numerator must be full([1], x) instead of scalar(x)
@@ -45,6 +68,14 @@ export class TransformerPositionalEncoding extends Module {
     this.encoding = this.calculate(0, this.sequenceLength) // shape [sequenceLength, dim]
   }
 
+  /**
+   * Calculate positional encodings at a given range of sequence positions.
+   *
+   * @param start - Start of the range to calculate
+   * @param end - End of the range to calculate
+   *
+   * @returns a Tensor of calculated positional embeddings with shape `[end - start, dim]`
+   */
   calculate(start: number, end: number): Tensor {
     const length = end - start
     const pairedDim = this.encodingFactors.shape[0]
@@ -63,6 +94,10 @@ export class TransformerPositionalEncoding extends Module {
     return encoding
   }
 
+  /**
+   * @param sequenceLength - Length of the sequence for which the positional embedding should be calculated
+   * @returns a Tensor of positional embeddings with shape `[length, dim]`, using precomputed values if available
+   */
   forward(sequenceLength: number): Tensor {
     if (sequenceLength > this.sequenceLength) {
       const extension = this.calculate(this.sequenceLength, sequenceLength)
@@ -130,10 +165,16 @@ function checkAttentionInputs(
   }
 }
 
+/**
+ * Scaled dot-product mechanism as described by Vaswani et al. The {@link scaleFactor} is computed during object creation as $\frac{1}{\sqrt{d}}$, where $d$ is the dimensionality of the inputs.
+ */
 export class TransformerDotProductAttention extends Module {
   private dim: number
   private scaleFactor: Tensor
 
+  /**
+   * @param dim - Number of dimensions of the inputs
+   */
   constructor(dim: number) {
     super()
     this.dim = dim
@@ -144,6 +185,12 @@ export class TransformerDotProductAttention extends Module {
     return tensor.mul(this.scaleFactor)
   }
 
+  /**
+   * @param queries - Tensor of query embeddings, shape `[..., queryTokens, dim]`
+   * @param keys - Tensor of key embeddings, shape `[..., keyTokens, dim]`
+   * @param values - Tensor of value embeddings each corresponding to a key, shape `[..., keyTokens, dim]`
+   * @returns A Tensor of shape `[..., queryTokens, dim]`
+   */
   forward(queries: Tensor, keys: Tensor, values: Tensor, mask?: Tensor): Tensor {
     // queries shape [..., queryTokens, dim]
     // keys and values shape [..., keyTokens, dim]
@@ -163,6 +210,9 @@ export class TransformerDotProductAttention extends Module {
   }
 }
 
+/**
+ * Multi-head attention mechanism as described by Vaswani et al. The input Tensors are linearly embedded before being passed to {@link TransformerDotProductAttention | scaled dot-product attentions}.
+ */
 export class TransformerMultiheadAttention extends Module {
   private dim: number
   private heads: number
@@ -173,6 +223,11 @@ export class TransformerMultiheadAttention extends Module {
   private attention: TransformerDotProductAttention
   private concatEmbed: Linear
 
+  /**
+   * @param dim - Number of dimensions of the input embeddings
+   * @param heads - Number of heads for the multi-head attention
+   * @param attentionDim - Number of dimensions of the further embeddings used by the {@link TransformerDotProductAttention | scaled dot-product attentions}, or `dim` if not specified
+   */
   constructor(dim: number, heads: number, attentionDim?: number) {
     super()
 
@@ -196,6 +251,12 @@ export class TransformerMultiheadAttention extends Module {
     this.concatEmbed = new Linear(this.attentionDim * heads, dim)
   }
 
+  /**
+   * @param queries - Tensor of query vectors, shape `[..., queryTokens, dim]`
+   * @param keys - Tensor of key vectors, shape `[..., keyTokens, dim]`
+   * @param values - Tensor of value vectors each corresponding to a key, shape `[..., keyTokens, dim]`
+   * @returns A Tensor of shape `[..., queryTokens, dim]`
+   */
   forward(queries: Tensor, keys: Tensor, values: Tensor): Tensor {
     // queries shape [..., queryTokens, dim]
     // keys and values shape [..., keyTokens, dim]
@@ -259,6 +320,9 @@ class FeedForward extends Module {
   }
 }
 
+/**
+ * A layer of the Transformer encoder, as described by Vaswani et al, consisting of a {@link TransformerMultiheadAttention | multi-head attention} layer and a fully-connected feed forward network. Both of these use residual connections and are normalised with {@link LayerNorm}.
+ */
 export class TransformerEncoderLayer extends Module {
   private dim: number
   private heads: number
@@ -269,6 +333,12 @@ export class TransformerEncoderLayer extends Module {
   private ff: FeedForward
   private ffNorm: LayerNorm
 
+  /**
+   * @param dim - Number of dimensions of the input embeddings
+   * @param heads - Number of heads for the multi-head attention
+   * @param attentionDim - Number of dimensions of the embeddings used in the scaled dot-product attention, or `dim` if not specified
+   * @param feedForwardDim - Number of dimensions in the hidden layer of the feed forward network, or `dim` if not specified
+   */
   constructor(dim: number, heads: number, attentionDim?: number, feedForwardDim?: number) {
     super()
 
@@ -291,6 +361,10 @@ export class TransformerEncoderLayer extends Module {
     this.ffNorm = new LayerNorm([this.dim])
   }
 
+  /**
+   * @param input - Input Tensor of shape `[..., tokens, dim]`
+   * @returns A Tensor of shape `[..., tokens, dim]`
+   */
   forward(input: Tensor): Tensor {
     // shape [..., tokens, dim]
     let mhaOutput = this.mha(input, input, input) // shape [..., tokens, dim]
@@ -303,6 +377,11 @@ export class TransformerEncoderLayer extends Module {
   }
 }
 
+/**
+ * Transformer encoder as described by Vaswani et al containing an arbitrary number of {@link TransformerEncoderLayer | TransformerEncoderLayers}.
+ *
+ * This module includes the {@link TransformerPositionalEncoding | positional encoding}, but does not include any initial embedding of an input sequence into vectors (which should have been separately done by e.g. word2vec).
+ */
 export class TransformerEncoder extends Module {
   private dim: number
   private heads: number
@@ -312,6 +391,14 @@ export class TransformerEncoder extends Module {
   private positional: TransformerPositionalEncoding
   private layers: Sequential
 
+  /**
+   * @param dim - Number of dimensions of the input embeddings
+   * @param heads - Number of heads for the multi-head attention
+   * @param depth - Number of encoder layers
+   * @param attentionDim - Number of dimensions of the embeddings used in the scaled dot-product attention, or `dim` if not specified
+   * @param feedForwardDim - Number of dimensions in the hidden layer of the feed forward network, or `dim` if not specified
+   * @param initSequenceLength - Initial sequence length that the positional embedding should be computed for, or {@link TransformerPositionalEncoding.DEFAULT_SEQUENCE_LENGTH} if not specified
+   */
   constructor(
     dim: number,
     heads: number,
@@ -351,6 +438,10 @@ export class TransformerEncoder extends Module {
     this.layers = new Sequential(...layers)
   }
 
+  /**
+   * @param input - Input Tensor of shape `[..., tokens, dim]`
+   * @returns A Tensor of shape `[..., tokens, dim]`
+   */
   forward(input: Tensor): Tensor {
     // shape [..., tokens, dim]
     const positionalEncoding = this.positional(input.shape[input.shape.length - 2]) // shape [tokens, dim]

--- a/shumai/module/transformer.ts
+++ b/shumai/module/transformer.ts
@@ -230,3 +230,29 @@ export class TransformerMultiheadAttention extends Module {
     return output
   }
 }
+
+class FeedForward extends Module {
+  private dim: number
+  private hiddenDim: number
+  private affineIn: Linear
+  private affineOut: Linear
+
+  constructor(dim: number, hiddenDim?: number) {
+    super()
+    this.dim = dim
+    if (hiddenDim === undefined) {
+      this.hiddenDim = dim
+    } else {
+      this.hiddenDim = hiddenDim
+    }
+    this.affineIn = new Linear(this.dim, this.hiddenDim)
+    this.affineOut = new Linear(this.hiddenDim, this.dim)
+  }
+
+  forward(input: Tensor): Tensor {
+    // shape [..., dim]
+    let output = this.affineIn(input).relu() // shape [..., hiddenDim]
+    output = this.affineOut(output) // shape [..., dim]
+    return output
+  }
+}

--- a/test/transformer.test.ts
+++ b/test/transformer.test.ts
@@ -496,3 +496,143 @@ describe('TransformerMultiheadAttention', () => {
     expect(!!values.grad).toBe(true)
   })
 })
+
+describe('TransformerEncoderLayer', () => {
+  it('single token, two heads', () => {
+    const module = new sm.module.TransformerEncoderLayer(6, 2)
+    const input = sm.tensor(new Float32Array([2, 3, 0.5, 0.25, 1, 2.25])).reshape([1, 6])
+
+    const result = module(input)
+    areSameShape(result, input)
+  })
+  it('single token, two heads (attentionDim)', () => {
+    const module = new sm.module.TransformerEncoderLayer(6, 2, 7)
+    const input = sm.tensor(new Float32Array([2, 3, 0.5, 0.25, 1, 2.25])).reshape([1, 6])
+
+    const result = module(input)
+    areSameShape(result, input)
+  })
+  it('single token, two heads (feedForwardDim)', () => {
+    const module = new sm.module.TransformerEncoderLayer(6, 2, 6, 12)
+    const input = sm.tensor(new Float32Array([2, 3, 0.5, 0.25, 1, 2.25])).reshape([1, 6])
+
+    const result = module(input)
+    areSameShape(result, input)
+  })
+  it('batch samples are independent', () => {
+    const module = new sm.module.TransformerEncoderLayer(6, 2)
+    const singleInput = sm.tensor(new Float32Array([2, 3, 0.5, 0.25, 1, 2.25])).reshape([1, 6])
+    const batchInput = sm
+      .tensor(
+        new Float32Array(
+          [2, 3, 0.5, 0.25, 1, 2.25].concat([
+            Math.random(),
+            Math.random(),
+            Math.random(),
+            Math.random(),
+            Math.random(),
+            Math.random()
+          ])
+        )
+      )
+      .reshape([2, 1, 6])
+
+    const singleResult = module(singleInput)
+    const batchResult = module(batchInput)
+    areSameShape(batchResult, batchInput)
+
+    expectArraysClose(
+      batchResult.index([0, ':', ':']).toFloat32Array(),
+      singleResult.toFloat32Array()
+    )
+    areSameShape(batchResult.index([0, ':', ':']), singleResult)
+  })
+  it('calculates gradient', () => {
+    const module = new sm.module.TransformerEncoderLayer(6, 2)
+    const input = sm
+      .tensor(new Float32Array([2, 3, 0.5, 0.25, 1, 2.25]))
+      .reshape([1, 6])
+      .requireGrad()
+
+    const result = module(input).sum()
+    result.backward()
+    expect(!!input.grad).toBe(true)
+  })
+})
+
+describe('TransformerEncoder', () => {
+  it('depth=1', () => {
+    const module = new sm.module.TransformerEncoder(6, 2, 1)
+    const input = sm.tensor(new Float32Array([2, 3, 0.5, 0.25, 1, 2.25])).reshape([1, 6])
+
+    const result = module(input)
+    areSameShape(result, input)
+  })
+  it('depth=2', () => {
+    const module = new sm.module.TransformerEncoder(6, 2, 2)
+    const input = sm.tensor(new Float32Array([2, 3, 0.5, 0.25, 1, 2.25])).reshape([1, 6])
+
+    const result = module(input)
+    areSameShape(result, input)
+  })
+  it('depth=2 (attentionDim)', () => {
+    const module = new sm.module.TransformerEncoder(6, 2, 2, 7)
+    const input = sm.tensor(new Float32Array([2, 3, 0.5, 0.25, 1, 2.25])).reshape([1, 6])
+
+    const result = module(input)
+    areSameShape(result, input)
+  })
+  it('depth=2 (feedForwardDim)', () => {
+    const module = new sm.module.TransformerEncoder(6, 2, 2, 6, 12)
+    const input = sm.tensor(new Float32Array([2, 3, 0.5, 0.25, 1, 2.25])).reshape([1, 6])
+
+    const result = module(input)
+    areSameShape(result, input)
+  })
+  it('depth=2 (initSequenceLength)', () => {
+    const module = new sm.module.TransformerEncoder(6, 2, 2, 6, 6, 1)
+    const input = sm.tensor(new Float32Array([2, 3, 0.5, 0.25, 1, 2.25])).reshape([1, 6])
+
+    const result = module(input)
+    areSameShape(result, input)
+  })
+  it('batch samples are independent', () => {
+    const module = new sm.module.TransformerEncoder(6, 2, 2)
+    const singleInput = sm.tensor(new Float32Array([2, 3, 0.5, 0.25, 1, 2.25])).reshape([1, 6])
+    const batchInput = sm
+      .tensor(
+        new Float32Array(
+          [2, 3, 0.5, 0.25, 1, 2.25].concat([
+            Math.random(),
+            Math.random(),
+            Math.random(),
+            Math.random(),
+            Math.random(),
+            Math.random()
+          ])
+        )
+      )
+      .reshape([2, 1, 6])
+
+    const singleResult = module(singleInput)
+    const batchResult = module(batchInput)
+    areSameShape(batchResult, batchInput)
+
+    expectArraysClose(
+      batchResult.index([0, ':', ':']).toFloat32Array(),
+      singleResult.toFloat32Array()
+    )
+    areSameShape(batchResult.index([0, ':', ':']), singleResult)
+  })
+  it('calculates gradient', () => {
+    const module = new sm.module.TransformerEncoder(6, 2, 2)
+    const input = sm
+      .tensor(new Float32Array([2, 3, 0.5, 0.25, 1, 2.25]))
+      .reshape([1, 6])
+      .requireGrad()
+
+    const result = module(input).sum()
+    result.backward()
+    expect(!!input.grad).toBe(true)
+  })
+})


### PR DESCRIPTION
### TransformerPositionalEncoding

$$ \mathrm{PE}_{i, 2z} = \sin \left( \frac{i}{10000^{2z/d}} \right) $$

$$ \mathrm{PE}_{i, 2z + 1} = \cos \left( \frac{i}{10000^{2z/d}} \right) $$

where $i$ is the sequence position, $2z$ and $2z+1$ are the dimensions of the input embedding, and $d$ is the dimensionality of the input embedding.

The multiplicative factors $\frac{1}{10000^{2z/d}}$ are precomputed during object creation as they are constant for all $i$.

The full PE is initially precomputed for all $i$ up to 256 (configurable). This is then extended and stored if the module is called with a sequence length larger than the initial value.

Returns a 2D tensor matching the last two dimensions of the input tensor to TransformerEncoder.

### FeedForward

Simple 2-layer fully connected neural network with relu activation. This is kept as a private class for now. If we want to make this to be exported it should probably be in a separate file.

### TransformerEncoderLayer 

As described in Vaswani et al.

### TransformerEncoder 

The full encoder half of the Transformer, using a Sequential containing arbitrary number of TransformerEncoderLayers.

This includes the positional encoding, but does not include any initial embedding of an input sequence into vectors (which would be separately done by e.g. word2vec)

