### PR TITLE
tweak `while` cond. in `isClose` per feedback/Move Float16Array Warning

### DIFF
--- a/shumai/tensor/tensor.ts
+++ b/shumai/tensor/tensor.ts
@@ -442,9 +442,6 @@ export class Tensor {
   valueOf() {
     switch (this.dtype) {
       case dtype.Float16:
-        console.warn(
-          'Float16Arrays are not natively supported by Bun, this will be polyfilled with a Float32Array'
-        )
         return this.elements == 1 ? this.toFloat16() : this.toFloat16Array()
       case dtype.Float32:
         return this.elements == 1 ? this.toFloat32() : this.toFloat32Array()
@@ -517,6 +514,9 @@ export class Tensor {
   }
 
   toFloat16Array() {
+    console.warn(
+      'Float16Arrays are not natively supported by Bun, this will be polyfilled with a Float32Array'
+    )
     const contig = this.asContiguousTensor()
     const elems = contig.elements
     return new Float16Array(toArrayBuffer(fl._float16Buffer.native(contig.ptr), 0, elems * 4))

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -69,7 +69,7 @@ export const isClose = (actual: number | bigint, expected: number | bigint, erro
 
   if (typeof actual === 'bigint' && typeof expected === 'bigint') {
     const factor = BigInt(10)
-    while (error.toString().includes('.')) {
+    while (error % 1 !== 0) {
       error *= 10
       actual *= factor
       expected *= factor


### PR DESCRIPTION
Moved the `console.warn` regarding no native JS Float16Array  into Tensor class method `toFloat16Array` so the warning will be logged if calling `valueOf` or directly calling `toFloat16Array`.

Additionally, updated the conditional used in the `while` loop in `isClose` per feedback from @yushiyangk! 