### PR TITLE
Implement `dispose`

### DIFF
--- a/shumai/ffi/ffi_tensor.ts
+++ b/shumai/ffi/ffi_tensor.ts
@@ -56,9 +56,6 @@ const ffi_tensor = {
   genTensorDestroyer: {
     returns: FFIType.ptr
   },
-  deallocationCtx: {
-    returns: FFIType.ptr
-  },
   dispose: {
     args: [FFIType.ptr]
   },

--- a/shumai/ffi/ffi_tensor.ts
+++ b/shumai/ffi/ffi_tensor.ts
@@ -56,6 +56,12 @@ const ffi_tensor = {
   genTensorDestroyer: {
     returns: FFIType.ptr
   },
+  deallocationCtx: {
+    returns: FFIType.ptr
+  },
+  dispose: {
+    args: [FFIType.ptr]
+  },
   tensorFromFloat16Buffer: {
     args: [FFIType.i64, FFIType.ptr],
     returns: FFIType.ptr

--- a/shumai/tensor/tensor.ts
+++ b/shumai/tensor/tensor.ts
@@ -2,7 +2,7 @@ import { ptr, toArrayBuffer } from 'bun:ffi'
 import { existsSync } from 'fs'
 import { arrayArg } from '../ffi/ffi_bind_utils'
 import { fl } from '../ffi/ffi_flashlight'
-import type { OpStats } from '../io'
+import type { OpStats } from '../network'
 import { cyrb53, Float16Array } from '../util'
 import { Grad } from './register_gradients'
 import { collectStats, getStack } from './stats'
@@ -429,6 +429,10 @@ export class Tensor {
 
   eval() {
     return fl._eval.native(this.ptr)
+  }
+
+  dispose() {
+    fl.dispose.native(this.ptr)
   }
 
   get ptr() {

--- a/shumai/tensor/tensor.ts
+++ b/shumai/tensor/tensor.ts
@@ -418,7 +418,7 @@ export class Tensor {
     return this
   }
 
-  save(filename) {
+  save(filename: string) {
     const cstr_buffer = new TextEncoder().encode(filename)
     return fl._save(this.ptr, cstr_buffer, cstr_buffer.length)
   }

--- a/test/dispose.test.ts
+++ b/test/dispose.test.ts
@@ -1,0 +1,17 @@
+import * as sm from '@shumai/shumai'
+import { describe, expect, it } from 'bun:test'
+
+describe('dispose', () => {
+  // currently segfaults; seems to GC twice
+  it('basic', () => {
+    const start_bytes = sm.bytesUsed()
+    for (let i = 0; i < 1000; i++) {
+      // Bun.gc(true)
+      const a = sm.tensor(new Float32Array([0, 1, 2, 3]))
+      a.dispose()
+      expect(sm.bytesUsed()).toBe(start_bytes)
+      // Bun.gc(true)
+    }
+    expect(sm.bytesUsed()).toBe(start_bytes)
+  })
+})

--- a/test/dispose.test.ts
+++ b/test/dispose.test.ts
@@ -2,15 +2,12 @@ import * as sm from '@shumai/shumai'
 import { describe, expect, it } from 'bun:test'
 
 describe('dispose', () => {
-  // currently segfaults; seems to GC twice
   it('basic', () => {
     const start_bytes = sm.bytesUsed()
     for (let i = 0; i < 1000; i++) {
-      // Bun.gc(true)
-      const a = sm.tensor(new Float32Array([0, 1, 2, 3]))
+      const a = sm.tensor(new Float32Array(new Array(100).fill(Math.random())))
       a.dispose()
       expect(sm.bytesUsed()).toBe(start_bytes)
-      // Bun.gc(true)
     }
     expect(sm.bytesUsed()).toBe(start_bytes)
   })


### PR DESCRIPTION
Bun appears to run GC twice; if you uncomment the logged output in `destroyTensor` (only called @ Garbage Collection), the output is logged multiple times per pointer).

This causes the test to segfault as first GC, bun finds the pointer in `alreadyDestroyed` & removes the pointer from the set. 2nd Garbage Collection, `destroyTensor` fails to locate the pointer in `alreadyDestroyed` (as it was just cleared @ the prev Garbage Collection run).

It seems like there might be a bug in Bun, working on a [repro](https://github.com/cryptodeal/GC_Bug) to file an issue w Bun as this is likely blocking.

Once we resolve the above, this will partially implement #50 (still want to implement some equivalent to TFJS `tidy` in a separate PR).