### PR TITLE
Masking in dot-product attention and allow unequal lengths for queries and keys

### DIFF
--- a/shumai/module/sequential.ts
+++ b/shumai/module/sequential.ts
@@ -28,27 +28,11 @@ export class Sequential extends Module {
       }
     }
 
-    if (inputs.length !== this._modules[0].forward.length) {
-      throw new Error(
-        `Module at index 0 expects ${this._modules[0].forward.length} arguments: got ${inputs.length}`
-      )
-    }
-
     let output: Tensor | Tensor[] = this._modules[0](...inputs)
     for (let i = 1; i < this._modules.length; i++) {
       if (output instanceof Array) {
-        if (output.length !== this._modules[i].forward.length) {
-          throw new Error(
-            `Module at index ${i} expects ${this._modules[i].forward.length} arguments: got ${output.length}`
-          )
-        }
         output = this._modules[i](...output)
       } else {
-        if (this._modules[i].forward.length !== 1) {
-          throw new Error(
-            `Module at index ${i} expects ${this._modules[i].forward.length} arguments: got 1`
-          )
-        }
         output = this._modules[i](output)
       }
     }

--- a/shumai/module/transformer.ts
+++ b/shumai/module/transformer.ts
@@ -9,16 +9,16 @@ const sm = { ...ops, ...tensor, util }
 
 export class TransformerDotProductAttention extends Module {
   private dim: number
-  private scale_factor: Tensor
+  private scaleFactor: Tensor
 
   constructor(dim: number) {
     super()
     this.dim = dim
-    this.scale_factor = sm.scalar(1 / Math.sqrt(dim))
+    this.scaleFactor = sm.scalar(1 / Math.sqrt(dim))
   }
 
   protected scale(tensor: Tensor): Tensor {
-    return tensor.mul(this.scale_factor)
+    return tensor.mul(this.scaleFactor)
   }
 
   forward(queries: Tensor, keys: Tensor, values: Tensor): Tensor {
@@ -49,14 +49,14 @@ export class TransformerDotProductAttention extends Module {
 export class TransformerMultiheadAttention extends Module {
   private dim: number
   private heads: number
-  private attn_dim: number
-  private query_embed: Linear
-  private key_embed: Linear
-  private value_embed: Linear
+  private attentionDim: number
+  private queryEmbed: Linear
+  private keyEmbed: Linear
+  private valueEmbed: Linear
   private attention: TransformerDotProductAttention
-  private concat_embed: Linear
+  private concatEmbed: Linear
 
-  constructor(dim: number, heads: number, attn_dim?: number) {
+  constructor(dim: number, heads: number, attentionDim?: number) {
     super()
 
     if (dim % heads !== 0) {
@@ -67,16 +67,16 @@ export class TransformerMultiheadAttention extends Module {
 
     this.dim = dim
     this.heads = heads
-    if (attn_dim === undefined) {
-      this.attn_dim = dim / heads
+    if (attentionDim === undefined) {
+      this.attentionDim = dim / heads
     } else {
-      this.attn_dim = attn_dim
+      this.attentionDim = attentionDim
     }
-    this.query_embed = new Linear(dim, this.attn_dim * heads)
-    this.key_embed = new Linear(dim, this.attn_dim * heads)
-    this.value_embed = new Linear(dim, this.attn_dim * heads)
-    this.attention = new TransformerDotProductAttention(this.attn_dim)
-    this.concat_embed = new Linear(this.attn_dim * heads, dim)
+    this.queryEmbed = new Linear(dim, this.attentionDim * heads)
+    this.keyEmbed = new Linear(dim, this.attentionDim * heads)
+    this.valueEmbed = new Linear(dim, this.attentionDim * heads)
+    this.attention = new TransformerDotProductAttention(this.attentionDim)
+    this.concatEmbed = new Linear(this.attentionDim * heads, dim)
   }
 
   forward(queries: Tensor, keys: Tensor, values: Tensor): Tensor {
@@ -99,28 +99,28 @@ export class TransformerMultiheadAttention extends Module {
 
     const reshape = [...shape] // [..., tokens, dim]
     reshape[reshape.length - 1] = this.heads
-    reshape.push(this.attn_dim) // [..., tokens, heads, attn_dim]
+    reshape.push(this.attentionDim) // [..., tokens, heads, attentionDim]
 
     // Swap 2nd and 3rd last axes
     const transpose = Array.from(sm.util.range(reshape.length))
     transpose[transpose.length - 3] = transpose.length - 2
     transpose[transpose.length - 2] = transpose.length - 3
 
-    queries = this.query_embed(queries).reshape(reshape).transpose(transpose)
-    keys = this.key_embed(keys).reshape(reshape).transpose(transpose)
-    values = this.value_embed(values).reshape(reshape).transpose(transpose)
-    // embed shape [..., tokens, heads * attn_dim]
-    // reshape shape [..., tokens, heads, attn_dim]
-    // transpose shape [..., heads, tokens, attn_dim]
+    queries = this.queryEmbed(queries).reshape(reshape).transpose(transpose)
+    keys = this.keyEmbed(keys).reshape(reshape).transpose(transpose)
+    values = this.valueEmbed(values).reshape(reshape).transpose(transpose)
+    // embed shape [..., tokens, heads * attentionDim]
+    // reshape shape [..., tokens, heads, attentionDim]
+    // transpose shape [..., heads, tokens, attentionDim]
 
     const reverseTranspose = transpose
     const reverseReshape = [...shape]
-    reverseReshape[reverseReshape.length - 1] = this.heads * this.attn_dim
+    reverseReshape[reverseReshape.length - 1] = this.heads * this.attentionDim
 
-    let output = this.attention(queries, keys, values) // shape [..., heads, tokens, attn_dim]
-    output = output.transpose(reverseTranspose) // shape [..., tokens, heads, attn_dim]
-    output = output.reshape(reverseReshape) // shape [..., tokens, heads * attn_dim]
-    output = this.concat_embed(output) // shape [batch, tokens, dim]
+    let output = this.attention(queries, keys, values) // shape [..., heads, tokens, attentionDim]
+    output = output.transpose(reverseTranspose) // shape [..., tokens, heads, attentionDim]
+    output = output.reshape(reverseReshape) // shape [..., tokens, heads * attentionDim]
+    output = this.concatEmbed(output) // shape [..., tokens, dim]
 
     return output
   }

--- a/test/sequential.test.ts
+++ b/test/sequential.test.ts
@@ -84,12 +84,12 @@ describe('Sequential', () => {
     expectArraysClose(result.toFloat32Array(), expected.toFloat32Array())
   })
   it('invalid number of args', () => {
-    const module = new sm.module.Linear(5, 3)
+    const module = new sm.module.LSTM(5, 3)
     const seq = new sm.module.Sequential(module)
     const tensor = sm.rand([5])
 
-    expectThrows(() => seq(), new RegExp('Module at index 0 expects .* arguments'))
-    expectThrows(() => seq(tensor, tensor), new RegExp('Module at index 0 expects .* arguments'))
+    expectThrows(() => seq())
+    expectThrows(() => seq(tensor))
   })
   it('invalid number of args between modules', () => {
     const module0 = new sm.module.Linear(5, 3)
@@ -97,7 +97,7 @@ describe('Sequential', () => {
     const seq = new sm.module.Sequential(module0, module1)
     const tensor = sm.rand([5])
 
-    expectThrows(() => seq(tensor), new RegExp('Module at index 1 expects .* arguments'))
+    expectThrows(() => seq(tensor))
   })
   it('invalid input tensor shape', () => {
     const module = new sm.module.Linear(5, 3)

--- a/test/transformer.test.ts
+++ b/test/transformer.test.ts
@@ -45,6 +45,19 @@ describe('TransformerDotProductAttention', () => {
     expect(result.index([0, 1]).toFloat32() > result.index([1, 0]).toFloat32()).toBe(true)
     expect(result.index([0, 0]).toFloat32() < result.index([1, 1]).toFloat32()).toBe(true)
   })
+  it('single query token, two key tokens', () => {
+    const module = new sm.module.TransformerDotProductAttention(3)
+
+    const queries = sm.tensor(new Float32Array([0, 0, 1])).reshape([1, 3])
+    const keys = sm.tensor(new Float32Array([0, 1, 0.25, 0, 0.5, 1])).reshape([2, 3])
+    const values = sm.tensor(new Float32Array([1, 0, 0, 0, 1, 0])).reshape([2, 3])
+
+    const result = module(queries, keys, values)
+    areSameShape(result, queries)
+
+    // Result 0 is more value 1 than value 0
+    expect(result.index([0, 1]).toFloat32() > result.index([0, 0]).toFloat32()).toBe(true)
+  })
   it('batch samples are independent', () => {
     const module = new sm.module.TransformerDotProductAttention(3)
 
@@ -105,14 +118,25 @@ describe('TransformerDotProductAttention', () => {
     )
     areSameShape(batchResult.index([0, ':', ':']), singleResult)
   })
-  it('differing shapes are invalid', () => {
+  it('differing shapes (except 2nd last axis) are invalid', () => {
     const module = new sm.module.TransformerDotProductAttention(3)
 
-    const queries = sm.tensor(new Float32Array([0, 0, 1, 0, 1, 0])).reshape([2, 3])
+    const queries = sm
+      .tensor(new Float32Array([0, 0, 1, 0, 1, 0, 0, 0, 1, 0, 1, 0]))
+      .reshape([2, 2, 3])
+    const keys = sm.tensor(new Float32Array([0, 1, 0.25, 0, 0.5, 1])).reshape([1, 2, 3])
+    const values = sm.tensor(new Float32Array([1, 0, 0, 0, 1, 0])).reshape([1, 2, 3])
+
+    expectThrows(() => module(queries, keys, values), new RegExp('must have the same shape'))
+  })
+  it('differing shapes (incl 2nd last axis) in keys and values are invalid', () => {
+    const module = new sm.module.TransformerDotProductAttention(3)
+
+    const queries = sm.tensor(new Float32Array([0, 1, 0])).reshape([1, 3])
     const keys = sm.tensor(new Float32Array([0, 1, 0.25])).reshape([1, 3])
     const values = sm.tensor(new Float32Array([1, 0, 0, 0, 1, 0])).reshape([2, 3])
 
-    expectThrows(() => module(queries, keys, values), new RegExp('should have the same shape'))
+    expectThrows(() => module(queries, keys, values), new RegExp('must have the same shape'))
   })
   it('differing dimensionalities are invalid', () => {
     const module = new sm.module.TransformerDotProductAttention(3)
@@ -121,7 +145,7 @@ describe('TransformerDotProductAttention', () => {
     const keys = sm.tensor(new Float32Array([0, 1, 0.25, 0, 0.5, 1])).reshape([2, 3])
     const values = sm.tensor(new Float32Array([1, 0, 0, 0, 1, 0])).reshape([1, 2, 3])
 
-    expectThrows(() => module(queries, keys, values), new RegExp('should have the same shape'))
+    expectThrows(() => module(queries, keys, values), new RegExp('must have the same shape'))
   })
   it('invalid dimensions', () => {
     const module = new sm.module.TransformerDotProductAttention(4)
@@ -130,7 +154,7 @@ describe('TransformerDotProductAttention', () => {
     const keys = sm.tensor(new Float32Array([0, 1, 0.25, 0, 0.5, 1])).reshape([2, 3])
     const values = sm.tensor(new Float32Array([1, 0, 0, 0, 1, 0])).reshape([2, 3])
 
-    expectThrows(() => module(queries, keys, values), new RegExp('must match module dimensions'))
+    expectThrows(() => module(queries, keys, values), new RegExp('must match attention dimension'))
   })
   it('calculates gradient', () => {
     const module = new sm.module.TransformerDotProductAttention(3)
@@ -166,7 +190,7 @@ describe('TransformerMultiheadAttention', () => {
     const result = module(queries, keys, values)
     areSameShape(result, queries)
   })
-  it('single token, single head (attn_dim)', () => {
+  it('single token, single head (attentionDim)', () => {
     const module = new sm.module.TransformerMultiheadAttention(3, 1, 7)
     const queries = sm.tensor(new Float32Array([0, 0, 1])).reshape([1, 3])
     const keys = sm.tensor(new Float32Array([0, 0, 0.5])).reshape([1, 3])
@@ -184,7 +208,7 @@ describe('TransformerMultiheadAttention', () => {
     const result = module(queries, keys, values)
     areSameShape(result, queries)
   })
-  it('single token, two heads (attn_dim)', () => {
+  it('single token, two heads (attentionDim)', () => {
     const module = new sm.module.TransformerMultiheadAttention(6, 2, 7)
     const queries = sm.tensor(new Float32Array([0, 0, 1, 0, 1, 0])).reshape([1, 6])
     const keys = sm.tensor(new Float32Array([0, 0, 0.5, 0.25, 1, 0])).reshape([1, 6])
@@ -272,7 +296,23 @@ describe('TransformerMultiheadAttention', () => {
       new RegExp('must be divisible by the number of heads')
     )
   })
-  it('differing shapes are invalid', () => {
+  it('differing shapes (except 2nd last axis) are invalid', () => {
+    const module = new sm.module.TransformerMultiheadAttention(6, 2)
+    const queries = sm
+      .tensor(
+        new Float32Array([0, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 1, 0, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 1])
+      )
+      .reshape([2, 2, 6])
+    const keys = sm
+      .tensor(new Float32Array([1, 2, 3, 4, 5, 6, 0, 0, 0.5, 0.25, 1, 0]))
+      .reshape([1, 2, 6])
+    const values = sm
+      .tensor(new Float32Array([1, 0, 0, 0, 1, 0, 3, 3, 3, 0, 0, 3]))
+      .reshape([1, 2, 6])
+
+    expectThrows(() => module(queries, keys, values), new RegExp('must have the same shape'))
+  })
+  it('differing shapes (incl 2nd last axis) in keys and values are invalid', () => {
     const module = new sm.module.TransformerMultiheadAttention(6, 2)
     const queries = sm
       .tensor(new Float32Array([0, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 1]))
@@ -280,7 +320,7 @@ describe('TransformerMultiheadAttention', () => {
     const keys = sm.tensor(new Float32Array([0, 0, 0.5, 0.25, 1, 0])).reshape([1, 6])
     const values = sm.tensor(new Float32Array([1, 0, 0, 0, 1, 0, 3, 3, 3, 0, 0, 3])).reshape([2, 6])
 
-    expectThrows(() => module(queries, keys, values), new RegExp('should have the same shape'))
+    expectThrows(() => module(queries, keys, values), new RegExp('must have the same shape'))
   })
   it('differing dimensionalities are invalid', () => {
     const module = new sm.module.TransformerMultiheadAttention(6, 2)
@@ -292,7 +332,7 @@ describe('TransformerMultiheadAttention', () => {
       .reshape([1, 2, 6])
     const values = sm.tensor(new Float32Array([1, 0, 0, 0, 1, 0, 3, 3, 3, 0, 0, 3])).reshape([2, 6])
 
-    expectThrows(() => module(queries, keys, values), new RegExp('should have the same shape'))
+    expectThrows(() => module(queries, keys, values), new RegExp('must have the same shape'))
   })
   it('invalid dimensions', () => {
     const module = new sm.module.TransformerMultiheadAttention(8, 2)
@@ -304,7 +344,7 @@ describe('TransformerMultiheadAttention', () => {
       .reshape([2, 6])
     const values = sm.tensor(new Float32Array([1, 0, 0, 0, 1, 0, 3, 3, 3, 0, 0, 3])).reshape([2, 6])
 
-    expectThrows(() => module(queries, keys, values), new RegExp('must match module dimensions'))
+    expectThrows(() => module(queries, keys, values), new RegExp('must match attention dimension'))
   })
   it('calculates gradient', () => {
     const module = new sm.module.TransformerMultiheadAttention(6, 2)

--- a/test/transformer.test.ts
+++ b/test/transformer.test.ts
@@ -58,6 +58,23 @@ describe('TransformerDotProductAttention', () => {
     // Result 0 is more value 1 than value 0
     expect(result.index([0, 1]).toFloat32() > result.index([0, 0]).toFloat32()).toBe(true)
   })
+  it('two tokens, one masked', () => {
+    const module = new sm.module.TransformerDotProductAttention(3)
+
+    const queries = sm.tensor(new Float32Array([0, 0, 1, 0, 1, 0])).reshape([2, 3])
+    const keys = sm.tensor(new Float32Array([0, 1, 0.25, 0, 0.5, 1])).reshape([2, 3])
+    const values = sm.tensor(new Float32Array([1, 0, 0, 0, 1, 0])).reshape([2, 3])
+    const mask = sm.tensor(new Int8Array([0, 1, 0, 0])).reshape([2, 2])
+
+    const result = module(queries, keys, values, mask)
+    areSameShape(result, queries)
+
+    // Result 0 is value 0 only
+    expectArraysClose(result.index([0, ':']).toFloat32Array(), [1, 0, 0])
+
+    // Result 1 is more value 0 than value 1
+    expect(result.index([1, 0]).toFloat32() > result.index([1, 1]).toFloat32()).toBe(true)
+  })
   it('batch samples are independent', () => {
     const module = new sm.module.TransformerDotProductAttention(3)
 


### PR DESCRIPTION
Various changes to the Transformer components to allow implementation of the decoder modules.

- Attention modules now take an optional mask parameter
- Attention modules now allow the queries and keys Tensors of different sequence lengths (i.e. their second last axis may differ in length). The other axes must be of the same shape, and the keys and values Tensors must be exactly the same shape.

Additionally, removed the check for input length in Sequential. The previously used method only works for a very narrow set of situations, and breaks when e.g. there are optional parameters. I could not find a safe and sane way of detecting the number of *required* arguments of a JavaScript function. As such, I have changed it to adopt a more permissive approach, and allow the member modules to generate their own errors if need be.