### PR TITLE
Fix ArrayFire 3.8.2. in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,7 +103,7 @@ jobs:
             - run:
                 name: "Install ArrayFire and CMake"
                 command: |
-                  brew install arrayfire cmake
+                  brew install arrayfire@3.8.2 cmake
       - when:
           condition:
             equal: [linux, << parameters.os >>]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,7 +101,7 @@ jobs:
             - run:
                 name: "Install ArrayFire and CMake"
                 command: |
-                  brew install cmake
+                  brew install arrayfire cmake
       - when:
           condition:
             equal: [linux, << parameters.os >>]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,8 +22,6 @@ executors:
     macos:
       xcode: 13.4.1
     resource_class: large
-    environment:
-      HOMEBREW_NO_AUTO_UPDATE: "1"
 
 commands:
   setup_arrayfire_apt:
@@ -103,7 +101,7 @@ jobs:
             - run:
                 name: "Install ArrayFire and CMake"
                 command: |
-                  brew install arrayfire@3.8.2 cmake
+                  brew install cmake
       - when:
           condition:
             equal: [linux, << parameters.os >>]


### PR DESCRIPTION
Fixes sporadic issues in ArrayFire 3.8.1 on macOS when installed via Homebrew. The CI Homebrew cache is fixed/won't update (to save CI time), but fixing the version should force a query against the remote package version cache.