### PR TITLE
Cleanup; use `private` keyword w `_` prefix for class private props

### DIFF
--- a/shumai/network/model.ts
+++ b/shumai/network/model.ts
@@ -1,5 +1,4 @@
 import type { Errorlike, Server } from 'bun'
-import * as crypto from 'crypto'
 import { OptimizerFn } from '../optim'
 import * as sm from '../tensor'
 import { backoff, decode, encode, tfetch } from './tensor'
@@ -258,7 +257,7 @@ export function serve_model(
   grad_update: OptimizerFn,
   options: ServeOpts,
   // TODO: pending further type refinement (requires a fn; same comments above)
-  req_map: Record<string, (...args: unknown[]) => Promise<unknown> | unknown | void>
+  req_map?: Record<string, (...args: unknown[]) => Promise<unknown> | unknown | void>
 ) {
   const base_req_map = {
     /* TODO: Refine type of param `u` */

--- a/shumai/network/runner.ts
+++ b/shumai/network/runner.ts
@@ -5,7 +5,7 @@ export function remote_runner(url) {
   async function get_logs() {
     const res = await fetch(`${url}/logs`)
     try {
-      return await res.json()
+      return await (<Promise<{ stdout: string; stderr: string }>>res.json())
     } catch (e) {
       return { stdout: '', stderr: '' }
     }
@@ -60,7 +60,7 @@ export function serve_runner() {
       await Bun.write(`entry.ts`, file)
       console.log('receieved new server file')
       // TODO find cleaner way to call `shumai serve_model`
-      bg_run = Bun.spawn(['bun', `${__dirname}/../run.ts`, 'serve_model', 'entry.ts'], {
+      bg_run = Bun.spawn(['bun', `${import.meta.dir}/../run.ts`, 'serve_model', 'entry.ts'], {
         stdout: Bun.file('stdout.log'),
         stderr: Bun.file('stderr.log')
       })

--- a/shumai/tensor/tensor_ops.ts
+++ b/shumai/tensor/tensor_ops.ts
@@ -1,5 +1,5 @@
 import type { Tensor } from './tensor'
-import { _var, erf, full, sigmoid } from './tensor_ops_gen'
+import { _var, full, sigmoid } from './tensor_ops_gen'
 
 export * from './tensor_ops_gen'
 

--- a/shumai/util/memory.ts
+++ b/shumai/util/memory.ts
@@ -6,9 +6,12 @@ export function tidy<T>(fn: (...args: any[]) => T, args: any | any[] = []): T {
   if (!Array.isArray(args)) args = [args]
   const result = fn(...args)
 
-  // lazy mark & sweep w `WeakSet` to avoid circ ref
+  /**
+   * recursively scan for `instanceof Tensor`;
+   * mark & sweep w `WeakSet` to avoid circ ref
+   */
   const prev_seen = new WeakSet()
-  const parseTidyRet = (result: any) => {
+  const parseTidyRet = (result: unknown) => {
     const res_type = typeof result
     if (
       res_type === 'number' ||

--- a/shumai/util/proc.ts
+++ b/shumai/util/proc.ts
@@ -1,9 +1,8 @@
 import { spawn } from 'bun'
-import { all, sleep } from '../util'
 
 /** Runs all arguments as commands in parallel. */
 export function run(...args) {
-  const procs = []
+  const procs: Promise<string>[] = []
   for (const arg of args) {
     const s = <ReadableStream>spawn(arg.split(' '), {
       stdout: 'pipe',

--- a/test/dispose.test.ts
+++ b/test/dispose.test.ts
@@ -177,8 +177,10 @@ describe('dispose', () => {
     const c = sm.randn([N, 1])
     const start_bytes = sm.bytesUsed()
 
+    /* eslint-disable @typescript-eslint/no-explicit-any */
     const mm_pw_op = (): [Record<string, any>, sm.Tensor[]] => {
       const out: Record<string, any> = {}
+      /* eslint-enable @typescript-eslint/no-explicit-any */
       for (let i = 0; i < 4; i++) {
         let iters = 0
         const record: Record<number, sm.Tensor> = {}
@@ -208,6 +210,7 @@ describe('dispose', () => {
       out['1'][199] = out['2']
       return [out, out_tensors]
     }
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const [, tensors] = sm.util.tidy<[Record<string, any>, sm.Tensor[]]>(mm_pw_op)
     for (let i = 0; i < tensors.length; i++) {
       expect(tensors[i] instanceof sm.Tensor).toBe(true)


### PR DESCRIPTION
General cleanup; per discussion with @bwasti, we'll stick w TS conventions and use `private` keyword + `_` prefix for private fields in classes in combination with getters when needed. 