### PR TITLE
cleanup network & runner

### DIFF
--- a/examples/remote_runner_example.ts
+++ b/examples/remote_runner_example.ts
@@ -15,7 +15,7 @@ let y = await f(x)
 const log = () => {
   return ` y[0] val: ${y.toFloat32()}`
 }
-for (const i of sm.util.viter(100000, log)) {
+for (const _i of sm.util.viter(100000, log)) {
   y = await f(x)
   const ref = x.mul(sm.scalar(2))
   sm.loss.mse(y, ref).backward()

--- a/shumai/network/model.ts
+++ b/shumai/network/model.ts
@@ -1,4 +1,4 @@
-import type { Errorlike, Server } from 'bun'
+import type { ServeOptions } from 'bun'
 import { OptimizerFn } from '../optim'
 import * as sm from '../tensor'
 import { backoff, decode, encode, tfetch } from './tensor'
@@ -57,19 +57,6 @@ export function remote_model(url: string, backward_url?: string, error_handler?)
   return forward
 }
 
-/* copy Bun's Serve Type, less fetch as we supply that logic */
-export type ServeOpts = {
-  port?: string | number
-  hostname?: string
-  baseURI?: string
-  maxRequestBodySize?: number
-  development?: boolean
-  error?: (
-    this: Server,
-    request: Errorlike
-  ) => Response | Promise<Response> | undefined | Promise<undefined>
-}
-
 export type OpStats = {
   bytes: bigint
   time: number
@@ -120,7 +107,7 @@ export type RouteStats = {
  */
 export function serve(
   request_dict: Record<string, (...args: unknown[]) => Promise<unknown> | unknown | void>,
-  options: ServeOpts
+  options: ServeOptions
 ) {
   const user_data = {}
   const statistics: Record<string, RouteStats> = {}
@@ -255,7 +242,7 @@ export function serve(
 export function serve_model(
   fn: (t: sm.Tensor) => sm.Tensor | Promise<sm.Tensor>,
   grad_update: OptimizerFn,
-  options: ServeOpts,
+  options: ServeOptions,
   // TODO: pending further type refinement (requires a fn; same comments above)
   req_map?: Record<string, (...args: unknown[]) => Promise<unknown> | unknown | void>
 ) {

--- a/shumai/network/runner.ts
+++ b/shumai/network/runner.ts
@@ -23,7 +23,7 @@ export function remote_runner(url) {
     logs: get_logs,
 
     async serve_model(file, port = 3000) {
-      const bundled = await run(
+      const [bundled] = await run(
         `esbuild --target=esnext --format=esm --platform=node --external:bun* --external:@shumai* --bundle ${file}`
       )
       await fetch(`${url}/serve_model`, {


### PR DESCRIPTION
Use Bun's `ServeOptions` type since that's exported from `bun-types` as of now; additionally, destructure `bundled` in `runner.ts` to fix a TypeError.