### PR TITLE
Fixed `triu` and `tril` being swapped

### DIFF
--- a/shumai/cpp/binding_gen.inl
+++ b/shumai/cpp/binding_gen.inl
@@ -4,7 +4,8 @@ void* _rand(void* shape_ptr, int64_t shape_len) {
     LOCK_GUARD
 
     auto shape = arrayArg<long long>(shape_ptr, shape_len, g_row_major, false);
-    auto t = fl::rand(fl::Shape(shape));
+    fl::Tensor t;
+    t = fl::rand(fl::Shape(shape));
     g_bytes_used += t.bytes();
     return new fl::Tensor(t);
   } catch (std::exception const& e) {
@@ -19,7 +20,8 @@ void* _randn(void* shape_ptr, int64_t shape_len) {
     LOCK_GUARD
 
     auto shape = arrayArg<long long>(shape_ptr, shape_len, g_row_major, false);
-    auto t = fl::randn(fl::Shape(shape));
+    fl::Tensor t;
+    t = fl::randn(fl::Shape(shape));
     g_bytes_used += t.bytes();
     return new fl::Tensor(t);
   } catch (std::exception const& e) {
@@ -34,7 +36,8 @@ void* _full(void* shape_ptr, int64_t shape_len, float val) {
     LOCK_GUARD
 
     auto shape = arrayArg<long long>(shape_ptr, shape_len, g_row_major, false);
-    auto t = fl::full(fl::Shape(shape), val);
+    fl::Tensor t;
+    t = fl::full(fl::Shape(shape), val);
     g_bytes_used += t.bytes();
     return new fl::Tensor(t);
   } catch (std::exception const& e) {
@@ -48,7 +51,8 @@ void* _identity(int64_t dim) {
   try {
     LOCK_GUARD
 
-    auto t = fl::identity(dim);
+    fl::Tensor t;
+    t = fl::identity(dim);
     g_bytes_used += t.bytes();
     return new fl::Tensor(t);
   } catch (std::exception const& e) {
@@ -62,7 +66,8 @@ void* _arange(float start, float end, float step) {
   try {
     LOCK_GUARD
 
-    auto t = fl::arange(start, end, step);
+    fl::Tensor t;
+    t = fl::arange(start, end, step);
     g_bytes_used += t.bytes();
     return new fl::Tensor(t);
   } catch (std::exception const& e) {
@@ -82,7 +87,8 @@ void* _iota(void* dims_ptr,
     auto dims = arrayArg<long long>(dims_ptr, dims_len, g_row_major, false);
     auto tileDims =
         arrayArg<long long>(tileDims_ptr, tileDims_len, g_row_major, false);
-    auto t = fl::iota(fl::Shape(dims), fl::Shape(tileDims));
+    fl::Tensor t;
+    t = fl::iota(fl::Shape(dims), fl::Shape(tileDims));
     g_bytes_used += t.bytes();
     return new fl::Tensor(t);
   } catch (std::exception const& e) {
@@ -98,7 +104,8 @@ void* _reshape(void* tensor, void* shape_ptr, int64_t shape_len) {
 
     auto* tensor_ptr = reinterpret_cast<fl::Tensor*>(tensor);
     auto shape = arrayArg<long long>(shape_ptr, shape_len, g_row_major, false);
-    auto t = fl::reshape(*tensor_ptr, fl::Shape(shape));
+    fl::Tensor t;
+    t = fl::reshape(*tensor_ptr, fl::Shape(shape));
     g_bytes_used += t.bytes();
     return new fl::Tensor(t);
   } catch (std::exception const& e) {
@@ -115,7 +122,8 @@ void* _transpose(void* tensor, void* axes_ptr, int64_t axes_len) {
     auto* tensor_ptr = reinterpret_cast<fl::Tensor*>(tensor);
     auto axes = arrayArg<long long>(axes_ptr, axes_len, g_row_major,
                                     tensor_ptr->ndim());
-    auto t = fl::transpose(*tensor_ptr, fl::Shape(axes));
+    fl::Tensor t;
+    t = fl::transpose(*tensor_ptr, fl::Shape(axes));
     g_bytes_used += t.bytes();
     return new fl::Tensor(t);
   } catch (std::exception const& e) {
@@ -131,7 +139,8 @@ void* _tile(void* tensor, void* shape_ptr, int64_t shape_len) {
 
     auto* tensor_ptr = reinterpret_cast<fl::Tensor*>(tensor);
     auto shape = arrayArg<long long>(shape_ptr, shape_len, g_row_major, false);
-    auto t = fl::tile(*tensor_ptr, fl::Shape(shape));
+    fl::Tensor t;
+    t = fl::tile(*tensor_ptr, fl::Shape(shape));
     g_bytes_used += t.bytes();
     return new fl::Tensor(t);
   } catch (std::exception const& e) {
@@ -147,7 +156,8 @@ void* _concatenate(void* tensors_ptr, int64_t tensors_len, int32_t axis) {
 
     auto tensors = ptrArrayArg<fl::Tensor>(tensors_ptr, tensors_len);
     auto used_axis = axisArg(axis, g_row_major, (&tensors[0])->ndim());
-    auto t = fl::concatenate(tensors, used_axis);
+    fl::Tensor t;
+    t = fl::concatenate(tensors, used_axis);
     g_bytes_used += t.bytes();
     return new fl::Tensor(t);
   } catch (std::exception const& e) {
@@ -162,7 +172,8 @@ void* _nonzero(void* tensor) {
     LOCK_GUARD
 
     auto* tensor_ptr = reinterpret_cast<fl::Tensor*>(tensor);
-    auto t = fl::nonzero(*tensor_ptr);
+    fl::Tensor t;
+    t = fl::nonzero(*tensor_ptr);
     g_bytes_used += t.bytes();
     return new fl::Tensor(t);
   } catch (std::exception const& e) {
@@ -177,7 +188,8 @@ void* _negative(void* tensor) {
     LOCK_GUARD
 
     auto* tensor_ptr = reinterpret_cast<fl::Tensor*>(tensor);
-    auto t = fl::negative(*tensor_ptr);
+    fl::Tensor t;
+    t = fl::negative(*tensor_ptr);
     g_bytes_used += t.bytes();
     return new fl::Tensor(t);
   } catch (std::exception const& e) {
@@ -192,7 +204,8 @@ void* _logicalNot(void* tensor) {
     LOCK_GUARD
 
     auto* tensor_ptr = reinterpret_cast<fl::Tensor*>(tensor);
-    auto t = fl::logicalNot(*tensor_ptr);
+    fl::Tensor t;
+    t = fl::logicalNot(*tensor_ptr);
     g_bytes_used += t.bytes();
     return new fl::Tensor(t);
   } catch (std::exception const& e) {
@@ -207,7 +220,8 @@ void* _exp(void* tensor) {
     LOCK_GUARD
 
     auto* tensor_ptr = reinterpret_cast<fl::Tensor*>(tensor);
-    auto t = fl::exp(*tensor_ptr);
+    fl::Tensor t;
+    t = fl::exp(*tensor_ptr);
     g_bytes_used += t.bytes();
     return new fl::Tensor(t);
   } catch (std::exception const& e) {
@@ -222,7 +236,8 @@ void* _log(void* tensor) {
     LOCK_GUARD
 
     auto* tensor_ptr = reinterpret_cast<fl::Tensor*>(tensor);
-    auto t = fl::log(*tensor_ptr);
+    fl::Tensor t;
+    t = fl::log(*tensor_ptr);
     g_bytes_used += t.bytes();
     return new fl::Tensor(t);
   } catch (std::exception const& e) {
@@ -237,7 +252,8 @@ void* _log1p(void* tensor) {
     LOCK_GUARD
 
     auto* tensor_ptr = reinterpret_cast<fl::Tensor*>(tensor);
-    auto t = fl::log1p(*tensor_ptr);
+    fl::Tensor t;
+    t = fl::log1p(*tensor_ptr);
     g_bytes_used += t.bytes();
     return new fl::Tensor(t);
   } catch (std::exception const& e) {
@@ -252,7 +268,8 @@ void* _sin(void* tensor) {
     LOCK_GUARD
 
     auto* tensor_ptr = reinterpret_cast<fl::Tensor*>(tensor);
-    auto t = fl::sin(*tensor_ptr);
+    fl::Tensor t;
+    t = fl::sin(*tensor_ptr);
     g_bytes_used += t.bytes();
     return new fl::Tensor(t);
   } catch (std::exception const& e) {
@@ -267,7 +284,8 @@ void* _cos(void* tensor) {
     LOCK_GUARD
 
     auto* tensor_ptr = reinterpret_cast<fl::Tensor*>(tensor);
-    auto t = fl::cos(*tensor_ptr);
+    fl::Tensor t;
+    t = fl::cos(*tensor_ptr);
     g_bytes_used += t.bytes();
     return new fl::Tensor(t);
   } catch (std::exception const& e) {
@@ -282,7 +300,8 @@ void* _sqrt(void* tensor) {
     LOCK_GUARD
 
     auto* tensor_ptr = reinterpret_cast<fl::Tensor*>(tensor);
-    auto t = fl::sqrt(*tensor_ptr);
+    fl::Tensor t;
+    t = fl::sqrt(*tensor_ptr);
     g_bytes_used += t.bytes();
     return new fl::Tensor(t);
   } catch (std::exception const& e) {
@@ -297,7 +316,8 @@ void* _tanh(void* tensor) {
     LOCK_GUARD
 
     auto* tensor_ptr = reinterpret_cast<fl::Tensor*>(tensor);
-    auto t = fl::tanh(*tensor_ptr);
+    fl::Tensor t;
+    t = fl::tanh(*tensor_ptr);
     g_bytes_used += t.bytes();
     return new fl::Tensor(t);
   } catch (std::exception const& e) {
@@ -312,7 +332,8 @@ void* _floor(void* tensor) {
     LOCK_GUARD
 
     auto* tensor_ptr = reinterpret_cast<fl::Tensor*>(tensor);
-    auto t = fl::floor(*tensor_ptr);
+    fl::Tensor t;
+    t = fl::floor(*tensor_ptr);
     g_bytes_used += t.bytes();
     return new fl::Tensor(t);
   } catch (std::exception const& e) {
@@ -327,7 +348,8 @@ void* _ceil(void* tensor) {
     LOCK_GUARD
 
     auto* tensor_ptr = reinterpret_cast<fl::Tensor*>(tensor);
-    auto t = fl::ceil(*tensor_ptr);
+    fl::Tensor t;
+    t = fl::ceil(*tensor_ptr);
     g_bytes_used += t.bytes();
     return new fl::Tensor(t);
   } catch (std::exception const& e) {
@@ -342,7 +364,8 @@ void* _rint(void* tensor) {
     LOCK_GUARD
 
     auto* tensor_ptr = reinterpret_cast<fl::Tensor*>(tensor);
-    auto t = fl::rint(*tensor_ptr);
+    fl::Tensor t;
+    t = fl::rint(*tensor_ptr);
     g_bytes_used += t.bytes();
     return new fl::Tensor(t);
   } catch (std::exception const& e) {
@@ -357,7 +380,8 @@ void* _absolute(void* tensor) {
     LOCK_GUARD
 
     auto* tensor_ptr = reinterpret_cast<fl::Tensor*>(tensor);
-    auto t = fl::absolute(*tensor_ptr);
+    fl::Tensor t;
+    t = fl::absolute(*tensor_ptr);
     g_bytes_used += t.bytes();
     return new fl::Tensor(t);
   } catch (std::exception const& e) {
@@ -372,7 +396,8 @@ void* _sigmoid(void* tensor) {
     LOCK_GUARD
 
     auto* tensor_ptr = reinterpret_cast<fl::Tensor*>(tensor);
-    auto t = fl::sigmoid(*tensor_ptr);
+    fl::Tensor t;
+    t = fl::sigmoid(*tensor_ptr);
     g_bytes_used += t.bytes();
     return new fl::Tensor(t);
   } catch (std::exception const& e) {
@@ -387,7 +412,8 @@ void* _erf(void* tensor) {
     LOCK_GUARD
 
     auto* tensor_ptr = reinterpret_cast<fl::Tensor*>(tensor);
-    auto t = fl::erf(*tensor_ptr);
+    fl::Tensor t;
+    t = fl::erf(*tensor_ptr);
     g_bytes_used += t.bytes();
     return new fl::Tensor(t);
   } catch (std::exception const& e) {
@@ -402,7 +428,8 @@ void* _flip(void* tensor, uint32_t dim) {
     LOCK_GUARD
 
     auto* tensor_ptr = reinterpret_cast<fl::Tensor*>(tensor);
-    auto t = fl::flip(*tensor_ptr, dim);
+    fl::Tensor t;
+    t = fl::flip(*tensor_ptr, dim);
     g_bytes_used += t.bytes();
     return new fl::Tensor(t);
   } catch (std::exception const& e) {
@@ -419,7 +446,8 @@ void* _clip(void* tensor, void* low, void* high) {
     auto* tensor_ptr = reinterpret_cast<fl::Tensor*>(tensor);
     auto* low_ptr = reinterpret_cast<fl::Tensor*>(low);
     auto* high_ptr = reinterpret_cast<fl::Tensor*>(high);
-    auto t = fl::clip(*tensor_ptr, *low_ptr, *high_ptr);
+    fl::Tensor t;
+    t = fl::clip(*tensor_ptr, *low_ptr, *high_ptr);
     g_bytes_used += t.bytes();
     return new fl::Tensor(t);
   } catch (std::exception const& e) {
@@ -435,7 +463,8 @@ void* _roll(void* tensor, int shift, int32_t axis) {
 
     auto* tensor_ptr = reinterpret_cast<fl::Tensor*>(tensor);
     auto used_axis = axisArg(axis, g_row_major, tensor_ptr->ndim());
-    auto t = fl::roll(*tensor_ptr, shift, used_axis);
+    fl::Tensor t;
+    t = fl::roll(*tensor_ptr, shift, used_axis);
     g_bytes_used += t.bytes();
     return new fl::Tensor(t);
   } catch (std::exception const& e) {
@@ -450,7 +479,8 @@ void* _isnan(void* tensor) {
     LOCK_GUARD
 
     auto* tensor_ptr = reinterpret_cast<fl::Tensor*>(tensor);
-    auto t = fl::isnan(*tensor_ptr);
+    fl::Tensor t;
+    t = fl::isnan(*tensor_ptr);
     g_bytes_used += t.bytes();
     return new fl::Tensor(t);
   } catch (std::exception const& e) {
@@ -465,7 +495,8 @@ void* _isinf(void* tensor) {
     LOCK_GUARD
 
     auto* tensor_ptr = reinterpret_cast<fl::Tensor*>(tensor);
-    auto t = fl::isinf(*tensor_ptr);
+    fl::Tensor t;
+    t = fl::isinf(*tensor_ptr);
     g_bytes_used += t.bytes();
     return new fl::Tensor(t);
   } catch (std::exception const& e) {
@@ -480,7 +511,8 @@ void* _sign(void* tensor) {
     LOCK_GUARD
 
     auto* tensor_ptr = reinterpret_cast<fl::Tensor*>(tensor);
-    auto t = fl::sign(*tensor_ptr);
+    fl::Tensor t;
+    t = fl::sign(*tensor_ptr);
     g_bytes_used += t.bytes();
     return new fl::Tensor(t);
   } catch (std::exception const& e) {
@@ -495,7 +527,12 @@ void* _tril(void* tensor) {
     LOCK_GUARD
 
     auto* tensor_ptr = reinterpret_cast<fl::Tensor*>(tensor);
-    auto t = fl::tril(*tensor_ptr);
+    fl::Tensor t;
+    if (g_row_major) {
+      t = fl::triu(*tensor_ptr);
+    } else {
+      t = fl::tril(*tensor_ptr);
+    }
     g_bytes_used += t.bytes();
     return new fl::Tensor(t);
   } catch (std::exception const& e) {
@@ -510,7 +547,12 @@ void* _triu(void* tensor) {
     LOCK_GUARD
 
     auto* tensor_ptr = reinterpret_cast<fl::Tensor*>(tensor);
-    auto t = fl::triu(*tensor_ptr);
+    fl::Tensor t;
+    if (g_row_major) {
+      t = fl::tril(*tensor_ptr);
+    } else {
+      t = fl::triu(*tensor_ptr);
+    }
     g_bytes_used += t.bytes();
     return new fl::Tensor(t);
   } catch (std::exception const& e) {
@@ -527,7 +569,8 @@ void* _where(void* cond, void* x, void* y) {
     auto* cond_ptr = reinterpret_cast<fl::Tensor*>(cond);
     auto* x_ptr = reinterpret_cast<fl::Tensor*>(x);
     auto* y_ptr = reinterpret_cast<fl::Tensor*>(y);
-    auto t = fl::where(cond_ptr->astype(fl::dtype::b8), *x_ptr, *y_ptr);
+    fl::Tensor t;
+    t = fl::where(cond_ptr->astype(fl::dtype::b8), *x_ptr, *y_ptr);
     g_bytes_used += t.bytes();
     return new fl::Tensor(t);
   } catch (std::exception const& e) {
@@ -542,7 +585,8 @@ void* _sort(void* tensor, uint32_t dim) {
     LOCK_GUARD
 
     auto* tensor_ptr = reinterpret_cast<fl::Tensor*>(tensor);
-    auto t = fl::sort(*tensor_ptr, dim);
+    fl::Tensor t;
+    t = fl::sort(*tensor_ptr, dim);
     g_bytes_used += t.bytes();
     return new fl::Tensor(t);
   } catch (std::exception const& e) {
@@ -558,7 +602,8 @@ void* _add(void* tensor, void* other) {
 
     auto* tensor_ptr = reinterpret_cast<fl::Tensor*>(tensor);
     auto* other_ptr = reinterpret_cast<fl::Tensor*>(other);
-    auto t = fl::add(*tensor_ptr, *other_ptr);
+    fl::Tensor t;
+    t = fl::add(*tensor_ptr, *other_ptr);
     g_bytes_used += t.bytes();
     return new fl::Tensor(t);
   } catch (std::exception const& e) {
@@ -574,7 +619,8 @@ void* _sub(void* tensor, void* other) {
 
     auto* tensor_ptr = reinterpret_cast<fl::Tensor*>(tensor);
     auto* other_ptr = reinterpret_cast<fl::Tensor*>(other);
-    auto t = fl::sub(*tensor_ptr, *other_ptr);
+    fl::Tensor t;
+    t = fl::sub(*tensor_ptr, *other_ptr);
     g_bytes_used += t.bytes();
     return new fl::Tensor(t);
   } catch (std::exception const& e) {
@@ -590,7 +636,8 @@ void* _mul(void* tensor, void* other) {
 
     auto* tensor_ptr = reinterpret_cast<fl::Tensor*>(tensor);
     auto* other_ptr = reinterpret_cast<fl::Tensor*>(other);
-    auto t = fl::mul(*tensor_ptr, *other_ptr);
+    fl::Tensor t;
+    t = fl::mul(*tensor_ptr, *other_ptr);
     g_bytes_used += t.bytes();
     return new fl::Tensor(t);
   } catch (std::exception const& e) {
@@ -606,7 +653,8 @@ void* _div(void* tensor, void* other) {
 
     auto* tensor_ptr = reinterpret_cast<fl::Tensor*>(tensor);
     auto* other_ptr = reinterpret_cast<fl::Tensor*>(other);
-    auto t = fl::div(*tensor_ptr, *other_ptr);
+    fl::Tensor t;
+    t = fl::div(*tensor_ptr, *other_ptr);
     g_bytes_used += t.bytes();
     return new fl::Tensor(t);
   } catch (std::exception const& e) {
@@ -622,7 +670,8 @@ void* _eq(void* tensor, void* other) {
 
     auto* tensor_ptr = reinterpret_cast<fl::Tensor*>(tensor);
     auto* other_ptr = reinterpret_cast<fl::Tensor*>(other);
-    auto t = fl::eq(*tensor_ptr, *other_ptr);
+    fl::Tensor t;
+    t = fl::eq(*tensor_ptr, *other_ptr);
     g_bytes_used += t.bytes();
     return new fl::Tensor(t);
   } catch (std::exception const& e) {
@@ -638,7 +687,8 @@ void* _neq(void* tensor, void* other) {
 
     auto* tensor_ptr = reinterpret_cast<fl::Tensor*>(tensor);
     auto* other_ptr = reinterpret_cast<fl::Tensor*>(other);
-    auto t = fl::neq(*tensor_ptr, *other_ptr);
+    fl::Tensor t;
+    t = fl::neq(*tensor_ptr, *other_ptr);
     g_bytes_used += t.bytes();
     return new fl::Tensor(t);
   } catch (std::exception const& e) {
@@ -654,7 +704,8 @@ void* _lessThan(void* tensor, void* other) {
 
     auto* tensor_ptr = reinterpret_cast<fl::Tensor*>(tensor);
     auto* other_ptr = reinterpret_cast<fl::Tensor*>(other);
-    auto t = fl::lessThan(*tensor_ptr, *other_ptr);
+    fl::Tensor t;
+    t = fl::lessThan(*tensor_ptr, *other_ptr);
     g_bytes_used += t.bytes();
     return new fl::Tensor(t);
   } catch (std::exception const& e) {
@@ -670,7 +721,8 @@ void* _lessThanEqual(void* tensor, void* other) {
 
     auto* tensor_ptr = reinterpret_cast<fl::Tensor*>(tensor);
     auto* other_ptr = reinterpret_cast<fl::Tensor*>(other);
-    auto t = fl::lessThanEqual(*tensor_ptr, *other_ptr);
+    fl::Tensor t;
+    t = fl::lessThanEqual(*tensor_ptr, *other_ptr);
     g_bytes_used += t.bytes();
     return new fl::Tensor(t);
   } catch (std::exception const& e) {
@@ -686,7 +738,8 @@ void* _greaterThan(void* tensor, void* other) {
 
     auto* tensor_ptr = reinterpret_cast<fl::Tensor*>(tensor);
     auto* other_ptr = reinterpret_cast<fl::Tensor*>(other);
-    auto t = fl::greaterThan(*tensor_ptr, *other_ptr);
+    fl::Tensor t;
+    t = fl::greaterThan(*tensor_ptr, *other_ptr);
     g_bytes_used += t.bytes();
     return new fl::Tensor(t);
   } catch (std::exception const& e) {
@@ -702,7 +755,8 @@ void* _greaterThanEqual(void* tensor, void* other) {
 
     auto* tensor_ptr = reinterpret_cast<fl::Tensor*>(tensor);
     auto* other_ptr = reinterpret_cast<fl::Tensor*>(other);
-    auto t = fl::greaterThanEqual(*tensor_ptr, *other_ptr);
+    fl::Tensor t;
+    t = fl::greaterThanEqual(*tensor_ptr, *other_ptr);
     g_bytes_used += t.bytes();
     return new fl::Tensor(t);
   } catch (std::exception const& e) {
@@ -718,7 +772,8 @@ void* _logicalOr(void* tensor, void* other) {
 
     auto* tensor_ptr = reinterpret_cast<fl::Tensor*>(tensor);
     auto* other_ptr = reinterpret_cast<fl::Tensor*>(other);
-    auto t = fl::logicalOr(*tensor_ptr, *other_ptr);
+    fl::Tensor t;
+    t = fl::logicalOr(*tensor_ptr, *other_ptr);
     g_bytes_used += t.bytes();
     return new fl::Tensor(t);
   } catch (std::exception const& e) {
@@ -734,7 +789,8 @@ void* _logicalAnd(void* tensor, void* other) {
 
     auto* tensor_ptr = reinterpret_cast<fl::Tensor*>(tensor);
     auto* other_ptr = reinterpret_cast<fl::Tensor*>(other);
-    auto t = fl::logicalAnd(*tensor_ptr, *other_ptr);
+    fl::Tensor t;
+    t = fl::logicalAnd(*tensor_ptr, *other_ptr);
     g_bytes_used += t.bytes();
     return new fl::Tensor(t);
   } catch (std::exception const& e) {
@@ -750,7 +806,8 @@ void* _mod(void* tensor, void* other) {
 
     auto* tensor_ptr = reinterpret_cast<fl::Tensor*>(tensor);
     auto* other_ptr = reinterpret_cast<fl::Tensor*>(other);
-    auto t = fl::mod(*tensor_ptr, *other_ptr);
+    fl::Tensor t;
+    t = fl::mod(*tensor_ptr, *other_ptr);
     g_bytes_used += t.bytes();
     return new fl::Tensor(t);
   } catch (std::exception const& e) {
@@ -766,7 +823,8 @@ void* _bitwiseAnd(void* tensor, void* other) {
 
     auto* tensor_ptr = reinterpret_cast<fl::Tensor*>(tensor);
     auto* other_ptr = reinterpret_cast<fl::Tensor*>(other);
-    auto t = fl::bitwiseAnd(*tensor_ptr, *other_ptr);
+    fl::Tensor t;
+    t = fl::bitwiseAnd(*tensor_ptr, *other_ptr);
     g_bytes_used += t.bytes();
     return new fl::Tensor(t);
   } catch (std::exception const& e) {
@@ -782,7 +840,8 @@ void* _bitwiseOr(void* tensor, void* other) {
 
     auto* tensor_ptr = reinterpret_cast<fl::Tensor*>(tensor);
     auto* other_ptr = reinterpret_cast<fl::Tensor*>(other);
-    auto t = fl::bitwiseOr(*tensor_ptr, *other_ptr);
+    fl::Tensor t;
+    t = fl::bitwiseOr(*tensor_ptr, *other_ptr);
     g_bytes_used += t.bytes();
     return new fl::Tensor(t);
   } catch (std::exception const& e) {
@@ -798,7 +857,8 @@ void* _bitwiseXor(void* tensor, void* other) {
 
     auto* tensor_ptr = reinterpret_cast<fl::Tensor*>(tensor);
     auto* other_ptr = reinterpret_cast<fl::Tensor*>(other);
-    auto t = fl::bitwiseXor(*tensor_ptr, *other_ptr);
+    fl::Tensor t;
+    t = fl::bitwiseXor(*tensor_ptr, *other_ptr);
     g_bytes_used += t.bytes();
     return new fl::Tensor(t);
   } catch (std::exception const& e) {
@@ -814,7 +874,8 @@ void* _lShift(void* tensor, void* other) {
 
     auto* tensor_ptr = reinterpret_cast<fl::Tensor*>(tensor);
     auto* other_ptr = reinterpret_cast<fl::Tensor*>(other);
-    auto t = fl::lShift(*tensor_ptr, *other_ptr);
+    fl::Tensor t;
+    t = fl::lShift(*tensor_ptr, *other_ptr);
     g_bytes_used += t.bytes();
     return new fl::Tensor(t);
   } catch (std::exception const& e) {
@@ -830,7 +891,8 @@ void* _rShift(void* tensor, void* other) {
 
     auto* tensor_ptr = reinterpret_cast<fl::Tensor*>(tensor);
     auto* other_ptr = reinterpret_cast<fl::Tensor*>(other);
-    auto t = fl::rShift(*tensor_ptr, *other_ptr);
+    fl::Tensor t;
+    t = fl::rShift(*tensor_ptr, *other_ptr);
     g_bytes_used += t.bytes();
     return new fl::Tensor(t);
   } catch (std::exception const& e) {
@@ -846,7 +908,8 @@ void* _minimum(void* tensor, void* other) {
 
     auto* tensor_ptr = reinterpret_cast<fl::Tensor*>(tensor);
     auto* other_ptr = reinterpret_cast<fl::Tensor*>(other);
-    auto t = fl::minimum(*tensor_ptr, *other_ptr);
+    fl::Tensor t;
+    t = fl::minimum(*tensor_ptr, *other_ptr);
     g_bytes_used += t.bytes();
     return new fl::Tensor(t);
   } catch (std::exception const& e) {
@@ -862,7 +925,8 @@ void* _maximum(void* tensor, void* other) {
 
     auto* tensor_ptr = reinterpret_cast<fl::Tensor*>(tensor);
     auto* other_ptr = reinterpret_cast<fl::Tensor*>(other);
-    auto t = fl::maximum(*tensor_ptr, *other_ptr);
+    fl::Tensor t;
+    t = fl::maximum(*tensor_ptr, *other_ptr);
     g_bytes_used += t.bytes();
     return new fl::Tensor(t);
   } catch (std::exception const& e) {
@@ -878,7 +942,8 @@ void* _power(void* tensor, void* other) {
 
     auto* tensor_ptr = reinterpret_cast<fl::Tensor*>(tensor);
     auto* other_ptr = reinterpret_cast<fl::Tensor*>(other);
-    auto t = fl::power(*tensor_ptr, *other_ptr);
+    fl::Tensor t;
+    t = fl::power(*tensor_ptr, *other_ptr);
     g_bytes_used += t.bytes();
     return new fl::Tensor(t);
   } catch (std::exception const& e) {
@@ -894,15 +959,14 @@ void* _matmul(void* tensor, void* other) {
 
     auto* tensor_ptr = reinterpret_cast<fl::Tensor*>(tensor);
     auto* other_ptr = reinterpret_cast<fl::Tensor*>(other);
+    fl::Tensor t;
     if (g_row_major) {
-      auto t = fl::matmul(*other_ptr, *tensor_ptr);
-      g_bytes_used += t.bytes();
-      return new fl::Tensor(t);
+      t = fl::matmul(*other_ptr, *tensor_ptr);
     } else {
-      auto t = fl::matmul(*tensor_ptr, *other_ptr);
-      g_bytes_used += t.bytes();
-      return new fl::Tensor(t);
+      t = fl::matmul(*tensor_ptr, *other_ptr);
     }
+    g_bytes_used += t.bytes();
+    return new fl::Tensor(t);
   } catch (std::exception const& e) {
     HANDLE_EXCEPTION(e.what());
   } catch (...) {
@@ -924,8 +988,8 @@ void* _conv2d(void* tensor,
 
     auto* tensor_ptr = reinterpret_cast<fl::Tensor*>(tensor);
     auto* weights_ptr = reinterpret_cast<fl::Tensor*>(weights);
-    auto t =
-        fl::conv2d(*tensor_ptr, *weights_ptr, sx, sy, px, py, dx, dy, groups);
+    fl::Tensor t;
+    t = fl::conv2d(*tensor_ptr, *weights_ptr, sx, sy, px, py, dx, dy, groups);
     g_bytes_used += t.bytes();
     return new fl::Tensor(t);
   } catch (std::exception const& e) {
@@ -942,7 +1006,8 @@ void* _amin(void* tensor, void* axes_ptr, int64_t axes_len, bool keep_dims) {
     auto* tensor_ptr = reinterpret_cast<fl::Tensor*>(tensor);
     auto axes =
         arrayArg<int>(axes_ptr, axes_len, g_row_major, tensor_ptr->ndim());
-    auto t = fl::amin(*tensor_ptr, axes, keep_dims);
+    fl::Tensor t;
+    t = fl::amin(*tensor_ptr, axes, keep_dims);
 
     auto axes_set = std::unordered_set<int>(axes.begin(), axes.end());
 
@@ -976,7 +1041,8 @@ void* _amax(void* tensor, void* axes_ptr, int64_t axes_len, bool keep_dims) {
     auto* tensor_ptr = reinterpret_cast<fl::Tensor*>(tensor);
     auto axes =
         arrayArg<int>(axes_ptr, axes_len, g_row_major, tensor_ptr->ndim());
-    auto t = fl::amax(*tensor_ptr, axes, keep_dims);
+    fl::Tensor t;
+    t = fl::amax(*tensor_ptr, axes, keep_dims);
 
     auto axes_set = std::unordered_set<int>(axes.begin(), axes.end());
 
@@ -1009,7 +1075,8 @@ void* _argmin(void* tensor, int32_t axis, bool keep_dims) {
 
     auto* tensor_ptr = reinterpret_cast<fl::Tensor*>(tensor);
     auto used_axis = axisArg(axis, g_row_major, tensor_ptr->ndim());
-    auto t = fl::argmin(*tensor_ptr, used_axis, keep_dims);
+    fl::Tensor t;
+    t = fl::argmin(*tensor_ptr, used_axis, keep_dims);
 
     auto axes_set = std::unordered_set<int>{static_cast<int>(used_axis)};
     auto base_shape = tensor_ptr->shape().get();
@@ -1041,7 +1108,8 @@ void* _argmax(void* tensor, int32_t axis, bool keep_dims) {
 
     auto* tensor_ptr = reinterpret_cast<fl::Tensor*>(tensor);
     auto used_axis = axisArg(axis, g_row_major, tensor_ptr->ndim());
-    auto t = fl::argmax(*tensor_ptr, used_axis, keep_dims);
+    fl::Tensor t;
+    t = fl::argmax(*tensor_ptr, used_axis, keep_dims);
 
     auto axes_set = std::unordered_set<int>{static_cast<int>(used_axis)};
     auto base_shape = tensor_ptr->shape().get();
@@ -1074,7 +1142,8 @@ void* _sum(void* tensor, void* axes_ptr, int64_t axes_len, bool keep_dims) {
     auto* tensor_ptr = reinterpret_cast<fl::Tensor*>(tensor);
     auto axes =
         arrayArg<int>(axes_ptr, axes_len, g_row_major, tensor_ptr->ndim());
-    auto t = fl::sum(*tensor_ptr, axes, keep_dims);
+    fl::Tensor t;
+    t = fl::sum(*tensor_ptr, axes, keep_dims);
 
     auto axes_set = std::unordered_set<int>(axes.begin(), axes.end());
 
@@ -1107,7 +1176,8 @@ void* _cumsum(void* tensor, int32_t axis) {
 
     auto* tensor_ptr = reinterpret_cast<fl::Tensor*>(tensor);
     auto used_axis = axisArg(axis, g_row_major, tensor_ptr->ndim());
-    auto t = fl::cumsum(*tensor_ptr, used_axis);
+    fl::Tensor t;
+    t = fl::cumsum(*tensor_ptr, used_axis);
     g_bytes_used += t.bytes();
     return new fl::Tensor(t);
   } catch (std::exception const& e) {
@@ -1124,7 +1194,8 @@ void* _mean(void* tensor, void* axes_ptr, int64_t axes_len, bool keep_dims) {
     auto* tensor_ptr = reinterpret_cast<fl::Tensor*>(tensor);
     auto axes =
         arrayArg<int>(axes_ptr, axes_len, g_row_major, tensor_ptr->ndim());
-    auto t = fl::mean(*tensor_ptr, axes, keep_dims);
+    fl::Tensor t;
+    t = fl::mean(*tensor_ptr, axes, keep_dims);
 
     auto axes_set = std::unordered_set<int>(axes.begin(), axes.end());
 
@@ -1158,7 +1229,8 @@ void* _median(void* tensor, void* axes_ptr, int64_t axes_len, bool keep_dims) {
     auto* tensor_ptr = reinterpret_cast<fl::Tensor*>(tensor);
     auto axes =
         arrayArg<int>(axes_ptr, axes_len, g_row_major, tensor_ptr->ndim());
-    auto t = fl::median(*tensor_ptr, axes, keep_dims);
+    fl::Tensor t;
+    t = fl::median(*tensor_ptr, axes, keep_dims);
 
     auto axes_set = std::unordered_set<int>(axes.begin(), axes.end());
 
@@ -1196,7 +1268,8 @@ void* _var(void* tensor,
     auto* tensor_ptr = reinterpret_cast<fl::Tensor*>(tensor);
     auto axes =
         arrayArg<int>(axes_ptr, axes_len, g_row_major, tensor_ptr->ndim());
-    auto t = fl::var(*tensor_ptr, axes, bias, keep_dims);
+    fl::Tensor t;
+    t = fl::var(*tensor_ptr, axes, bias, keep_dims);
 
     auto axes_set = std::unordered_set<int>(axes.begin(), axes.end());
 
@@ -1230,7 +1303,8 @@ void* _std(void* tensor, void* axes_ptr, int64_t axes_len, bool keep_dims) {
     auto* tensor_ptr = reinterpret_cast<fl::Tensor*>(tensor);
     auto axes =
         arrayArg<int>(axes_ptr, axes_len, g_row_major, tensor_ptr->ndim());
-    auto t = fl::std(*tensor_ptr, axes, keep_dims);
+    fl::Tensor t;
+    t = fl::std(*tensor_ptr, axes, keep_dims);
 
     auto axes_set = std::unordered_set<int>(axes.begin(), axes.end());
 
@@ -1268,7 +1342,8 @@ void* _norm(void* tensor,
     auto* tensor_ptr = reinterpret_cast<fl::Tensor*>(tensor);
     auto axes =
         arrayArg<int>(axes_ptr, axes_len, g_row_major, tensor_ptr->ndim());
-    auto t = fl::norm(*tensor_ptr, axes, p, keep_dims);
+    fl::Tensor t;
+    t = fl::norm(*tensor_ptr, axes, p, keep_dims);
 
     if (p == std::numeric_limits<double>::infinity()) {
       t = fl::abs(*tensor_ptr);
@@ -1310,7 +1385,8 @@ void* _countNonzero(void* tensor,
     auto* tensor_ptr = reinterpret_cast<fl::Tensor*>(tensor);
     auto axes =
         arrayArg<int>(axes_ptr, axes_len, g_row_major, tensor_ptr->ndim());
-    auto t = fl::countNonzero(*tensor_ptr, axes, keep_dims);
+    fl::Tensor t;
+    t = fl::countNonzero(*tensor_ptr, axes, keep_dims);
 
     auto axes_set = std::unordered_set<int>(axes.begin(), axes.end());
 
@@ -1344,7 +1420,8 @@ void* _any(void* tensor, void* axes_ptr, int64_t axes_len, bool keep_dims) {
     auto* tensor_ptr = reinterpret_cast<fl::Tensor*>(tensor);
     auto axes =
         arrayArg<int>(axes_ptr, axes_len, g_row_major, tensor_ptr->ndim());
-    auto t = fl::any(*tensor_ptr, axes, keep_dims);
+    fl::Tensor t;
+    t = fl::any(*tensor_ptr, axes, keep_dims);
 
     auto axes_set = std::unordered_set<int>(axes.begin(), axes.end());
 
@@ -1378,7 +1455,8 @@ void* _all(void* tensor, void* axes_ptr, int64_t axes_len, bool keep_dims) {
     auto* tensor_ptr = reinterpret_cast<fl::Tensor*>(tensor);
     auto axes =
         arrayArg<int>(axes_ptr, axes_len, g_row_major, tensor_ptr->ndim());
-    auto t = fl::all(*tensor_ptr, axes, keep_dims);
+    fl::Tensor t;
+    t = fl::all(*tensor_ptr, axes, keep_dims);
 
     auto axes_set = std::unordered_set<int>(axes.begin(), axes.end());
 

--- a/test/triu_tril.test.ts
+++ b/test/triu_tril.test.ts
@@ -1,0 +1,19 @@
+import * as sm from '@shumai/shumai'
+import { describe, expect, it } from 'bun:test'
+import { expectArraysClose, isShape } from './utils'
+
+describe('triu', () => {
+  it('basic', () => {
+    const tensor = sm.full([3, 3], 1).triu()
+    expect(isShape(tensor, [3, 3])).toBe(true)
+    expectArraysClose(tensor.toFloat32Array(), new Float32Array([1, 1, 1, 0, 1, 1, 0, 0, 1]))
+  })
+})
+
+describe('tril', () => {
+  it('basic', () => {
+    const tensor = sm.full([3, 3], 1).tril()
+    expect(isShape(tensor, [3, 3])).toBe(true)
+    expectArraysClose(tensor.toFloat32Array(), new Float32Array([1, 0, 0, 1, 1, 0, 1, 1, 1]))
+  })
+})


### PR DESCRIPTION
As discussed on discord, `sm.tril` should call `fl::triu`  instead of `fl::tril` when using row major, and vice versa.