### PR TITLE
add separate tsconfig for typedoc gen

### DIFF
--- a/examples/client.ts
+++ b/examples/client.ts
@@ -1,7 +1,7 @@
 import * as sm from '@shumai/shumai'
 
 const url = '127.0.0.1:3001'
-const model = sm.io.remote_model(url)
+const model = sm.network.remote_model(url)
 
 const ref_weight = sm.full([128, 8], 1)
 let loss

--- a/examples/distributed/differentiate_through_remote_model.ts
+++ b/examples/distributed/differentiate_through_remote_model.ts
@@ -1,7 +1,7 @@
 import * as sm from '@shumai/shumai'
 
 // remote identity function
-const model = sm.io.remote_model('0.0.0.0:3000')
+const model = sm.network.remote_model('0.0.0.0:3000')
 
 const val = sm.scalar(1).requireGrad()
 

--- a/examples/distributed/identity_server.ts
+++ b/examples/distributed/identity_server.ts
@@ -1,7 +1,7 @@
 import * as sm from '@shumai/shumai'
 
-function identity(x) {
+function identity(x: sm.Tensor) {
   return x
 }
 
-sm.io.serve_model(identity)
+sm.network.serve_model(identity)

--- a/examples/distributed/model_a.ts
+++ b/examples/distributed/model_a.ts
@@ -1,6 +1,9 @@
 import * as sm from '@shumai/shumai'
 
 class MLP extends sm.module.Module {
+  public l0
+  public l1
+  public l2
   constructor() {
     super()
     this.l0 = sm.module.linear(8, 8)

--- a/examples/distributed/model_b.ts
+++ b/examples/distributed/model_b.ts
@@ -1,6 +1,9 @@
 import * as sm from '@shumai/shumai'
 
 class MLP extends sm.module.Module {
+  public l0
+  public l1
+  public l2
   constructor() {
     super()
     this.l0 = sm.module.linear(8, 8)

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "module": "shumai/index.ts",
   "type": "module",
   "scripts": {
-    "format": "eslint '**/*.{js,ts}' '*.{js,ts,cjs}' package.json --fix"
+    "format": "eslint '**/*.{js,ts}' '*.{js,ts,cjs}' package.json --fix",
+    "typedoc": "typedoc --tsconfig tsconfig.typedoc.json"
   },
   "bin": {
     "shumai": "./shumai/run.ts"

--- a/shumai/network/model.ts
+++ b/shumai/network/model.ts
@@ -241,8 +241,8 @@ export function serve(
  */
 export function serve_model(
   fn: (t: sm.Tensor) => sm.Tensor | Promise<sm.Tensor>,
-  grad_update: OptimizerFn,
-  options: ServeOptions,
+  grad_update?: OptimizerFn,
+  options?: ServeOptions,
   // TODO: pending further type refinement (requires a fn; same comments above)
   req_map?: Record<string, (...args: unknown[]) => Promise<unknown> | unknown | void>
 ) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,12 +15,5 @@
       "@shumai/shumai": ["./shumai/index.ts"],
     }
   },
-  "exclude": ["examples/**/*.js", "build/**/*", "docs/assets/**/*"],
-  "typedocOptions": {
-    "entryPoints": ["shumai/index.ts"],
-    "out": "docs",
-    "readme": "docs.md",
-    "searchInComments": true,
-    "plugin": ["typedoc-plugin-katex"]
-  }
+  "exclude": ["examples/**/*.js", "build/**/*", "docs/assets/**/*"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,7 @@
       "@shumai/shumai": ["./shumai/index.ts"],
     }
   },
-  "exclude": ["build/**/*", "docs/assets/**/*"],
+  "exclude": ["examples/**/*.js", "build/**/*", "docs/assets/**/*"],
   "typedocOptions": {
     "entryPoints": ["shumai/index.ts"],
     "out": "docs",

--- a/tsconfig.typedoc.json
+++ b/tsconfig.typedoc.json
@@ -15,7 +15,7 @@
       "@shumai/shumai": ["./shumai/index.ts"],
     }
   },
-  "exclude": ["build/**/*", "docs/assets/**/*"],
+  "exclude": ["examples/**/*", "build/**/*", "docs/assets/**/*"],
   "typedocOptions": {
     "entryPoints": ["shumai/index.ts"],
     "out": "docs",


### PR DESCRIPTION
`typedoc` allows passing a cli arg that specifies that path of the `tsconfig.json` file to be used; accordingly, we now leverage this to specify that `typedoc` should use `tsconfig.typedoc.json`; this allows us to `exclude: ['examples/**/*']` in `tsconfig.typedoc.json` whereas we include in `tsconfig.json`! 