### PR TITLE
Tidy optimizers, nested tidy support, and no forced GCs

### DIFF
--- a/shumai/optim/adam.ts
+++ b/shumai/optim/adam.ts
@@ -1,4 +1,5 @@
 import * as sm from '../tensor'
+import { tidy } from '../util/memory'
 import { Optimizer } from './optim'
 
 export class Adam extends Optimizer {
@@ -19,25 +20,30 @@ export class Adam extends Optimizer {
     this.t = 0
   }
   step(grads: Record<string, { grad: sm.Tensor; tensor: sm.Tensor; id: number }>) {
-    const one = sm.scalar(1)
-    this.t = this.t + 1
-    const b1_p = this.b1.power(sm.scalar(this.t))
-    const b2_p = this.b2.power(sm.scalar(this.t))
-    // sqrt(1 - b2^t) / sqrt(1 - b1^t)
-    const decay = sm.sqrt(one.sub(b2_p)).div(sm.sqrt(one.sub(b1_p)))
-    const a = this.lr.mul(decay)
-    for (const [, v] of Object.entries(grads)) {
-      const { tensor: t, grad: g_, id: id } = v
-      const g = g_.detach()
-      if (this.m[id] === undefined) {
-        this.m[id] = sm.full(t.shape, 0)
-        this.v[id] = sm.full(t.shape, 0)
+    tidy(() => {
+      const one = sm.scalar(1)
+      this.t = this.t + 1
+      const b1_p = this.b1.power(sm.scalar(this.t))
+      const b2_p = this.b2.power(sm.scalar(this.t))
+      // sqrt(1 - b2^t) / sqrt(1 - b1^t)
+      const decay = sm.sqrt(one.sub(b2_p)).div(sm.sqrt(one.sub(b1_p)))
+      const a = this.lr.mul(decay)
+      for (const [, v] of Object.entries(grads)) {
+        const { tensor: t, grad: g_, id: id } = v
+        const g = g_.detach()
+        if (this.m[id] === undefined) {
+          this.m[id] = sm.full(t.shape, 0).untidy()
+          this.v[id] = sm.full(t.shape, 0).untidy()
+        }
+        this.m[id] = this.b1.mul(this.m[id]).add(one.sub(this.b1).mul(g)).untidy()
+        this.v[id] = this.b2
+          .mul(this.v[id])
+          .add(one.sub(this.b2).mul(g.mul(g)))
+          .untidy()
+        const delta = a.mul(this.m[id].div(this.v[id].sqrt()).add(this.eps))
+        t.update(t.detach().sub(delta)).untidy()
+        t.grad = null
       }
-      this.m[id] = this.b1.mul(this.m[id]).add(one.sub(this.b1).mul(g))
-      this.v[id] = this.b2.mul(this.v[id]).add(one.sub(this.b2).mul(g.mul(g)))
-      const delta = a.mul(this.m[id].div(this.v[id].sqrt()).add(this.eps))
-      t.update(t.detach().sub(delta))
-      t.grad = null
-    }
+    })
   }
 }

--- a/shumai/optim/sgd.ts
+++ b/shumai/optim/sgd.ts
@@ -1,15 +1,18 @@
 import * as sm from '../tensor'
+import { tidy } from '../util/memory'
 
 export function sgd(
   grads: Record<string, { grad: sm.Tensor; tensor: sm.Tensor }>,
   learning_rate = 1e-3
 ) {
-  const lr = sm.scalar(-learning_rate)
-  for (const [, v] of Object.entries(grads)) {
-    const { tensor: t, grad: g } = v
-    if (t.requires_grad) {
-      t.update(t.detach().add(g.detach().mul(lr)))
+  tidy(() => {
+    const lr = sm.scalar(-learning_rate)
+    for (const [, v] of Object.entries(grads)) {
+      const { tensor: t, grad: g } = v
+      if (t.requires_grad) {
+        t.update(t.detach().add(g.detach().mul(lr))).untidy()
+      }
+      t.grad = null
     }
-    t.grad = null
-  }
+  })
 }

--- a/shumai/tensor/tensor.ts
+++ b/shumai/tensor/tensor.ts
@@ -411,15 +411,12 @@ export class Tensor {
     this._ptr = ptr(tensor._underlying)
     this._deps = tensor.deps
     this.eval()
-    // TODO do this only when necessary from C++
-    if (fl.bytesUsed.native() > 10e6 /* 10MB */) {
-      Bun.gc(true)
-    }
     if (this._checkpoint_file) {
       if (this._checkpoint_callback()) {
         this.save(this._checkpoint_file)
       }
     }
+    return this
   }
 
   checkpoint(file?: (() => boolean) | any, callback?: () => boolean) {
@@ -575,6 +572,11 @@ export class Tensor {
     t.grad = null
     t._deps = []
     return t
+  }
+
+  untidy() {
+    _tidyTracker?.delete(this.ptr)
+    return this
   }
 
   get elements() {

--- a/shumai/tensor/tensor_ops.ts
+++ b/shumai/tensor/tensor_ops.ts
@@ -52,5 +52,9 @@ export function hardTanh(tensor: Tensor): Tensor {
 const geluConst = 1 / Math.sqrt(2)
 export function gelu(tensor: Tensor): Tensor {
   // https://arxiv.org/pdf/1606.08415.pdf
-  return tensor.mul(scalar(0.5)).mul(scalar(1.0).add(tensor.mul(scalar(geluConst))).erf())
+  return tensor.mul(scalar(0.5)).mul(
+    scalar(1.0)
+      .add(tensor.mul(scalar(geluConst)))
+      .erf()
+  )
 }


### PR DESCRIPTION
Partially addresses https://github.com/facebookresearch/shumai/issues/125 but this PR mainly addresses memory leaks during back-prop optimization. Hopefully supporting nested tidy's will encourage internal usage without worry of side-effects from calling apps also using `tidy`.