### PR TITLE
Making softmax numerically stable

### DIFF
--- a/shumai/tensor/register_gradients.ts
+++ b/shumai/tensor/register_gradients.ts
@@ -48,6 +48,11 @@ const impls = {
   add: (ctx: GradContext) => {
     return possiblyReduce(ctx.backward_input, ctx)
   },
+  amax: (ctx: GradContext) => {
+    return ctx.backward_input
+      .mul(ctx.forward_inputs[0].eq(ctx.forward_output).astype(ctx.backward_input.dtype))
+      .sum(ctx.forward_inputs[1], ctx.forward_inputs[2])
+  },
   conv2d: (ctx: GradContext) => {
     const [x, w, sx, sy, px, py, dx, dy, g] = <
       [Tensor, Tensor, number, number, number, number, number, number, number]

--- a/shumai/tensor/tensor_ops.ts
+++ b/shumai/tensor/tensor_ops.ts
@@ -8,7 +8,7 @@ export function scalar(s: number): Tensor {
 }
 
 export function softmax(tensor: Tensor, axis: number): Tensor {
-  const exp = tensor.exp()
+  const exp = tensor.sub(tensor.amax([axis], true)).exp()
   return exp.div(exp.sum([axis], true))
 }
 

--- a/test/gradient.test.ts
+++ b/test/gradient.test.ts
@@ -30,6 +30,10 @@ function checkGrad(f, args, idx, jacobian, epsilon = 1e-3) {
 }
 
 describe('gradients', () => {
+  it('amax', () => {
+    const a = sm.randn([128])
+    checkGrad(sm.amax, [a, [0], true], 0, sampleSphere(a.shape))
+  })
   it('mul', () => {
     const a = sm.randn([128])
     const b = sm.randn([128])

--- a/test/softmax.test.ts
+++ b/test/softmax.test.ts
@@ -212,4 +212,9 @@ describe('softmax', () => {
     const result0 = tensor.softmax(0)
     expectArraysClose(result0.index([':', 0]).toFloat32Array(), [NaN, NaN])
   })
+  it('numerically stable', () => {
+    const tensor = sm.tensor(new Float32Array([1000, 0, 0]))
+    const result = tensor.softmax(0)
+    expect(result.toFloat32Array().some(Number.isNaN)).toBe(false)
+  })
 })


### PR DESCRIPTION
Modified the softmax function to be numerically stable with large exponents. Method taken from [here](https://cs231n.github.io/linear-classify/#softmax-classifier).

I am fairly new to autodiff gradient functions, so my implementation of `amax` may be way off the mark (it certainly _looks_ wrong).

I originally wrote the below code based on the min/max gradient functions that already exist, but it would not converge my test model (where the current implementation does).
```ts
const mask = ctx.forward_inputs[0]
  .eq(ctx.forward_output)
  .astype(ctx.backward_input.dtype);
return ctx.backward_input.mul(mask)
```