### PR TITLE
Fix log gradient test

### DIFF
--- a/test/gradient.test.ts
+++ b/test/gradient.test.ts
@@ -83,7 +83,7 @@ describe('gradients', () => {
     checkGrad(sm.abs, [a], 0, sampleSphere(a.shape))
   })
   it('log', () => {
-    const a = sm.randn([128]).add(sm.scalar(1))
+    const a = sm.randn([128]).add(sm.scalar(2))
     checkGrad(sm.log, [a], 0, sampleSphere(a.shape))
   })
 })


### PR DESCRIPTION
I guess there was still a (small) probability `randn + 1` could still be up against 0.