### PR TITLE
Add mae, cross-entropy, and binary cross-entropy loss fns

### DIFF
--- a/shumai/loss/index.ts
+++ b/shumai/loss/index.ts
@@ -1,3 +1,38 @@
 import * as sm from '../tensor'
-export type LossFn = (a: sm.Tensor, b: sm.Tensor) => sm.Tensor
 export * from './mse'
+
+export type LossFn = (a: sm.Tensor, b: sm.Tensor) => sm.Tensor
+
+/**
+ * Cross-entropy loss for multi-class classification
+ * Use with softmax on the final activation layer
+ *
+ * $$-\sum_{k=1}^Ky_{i,k}\log\hat{y}_{i,k}$$
+ */
+export function crossEntropy(): LossFn {
+  return (y, p) => sm.mul(sm.scalar(-1), sm.mean(sm.sum(sm.mul(y, clippedLog(p)), [1])))
+}
+
+/**
+ * Binary cross-entropy loss for two-class classification
+ * Use with sigmoid on the final activation layer
+ *
+ * $$-y_i\log\hat{y}_i+(1-y_i)\log(1-\hat{y}_i)$$
+ */
+export function binaryCrossEntropy(): LossFn {
+  return (y, p) =>
+    sm.mul(
+      sm.scalar(-1),
+      sm.mean(
+        sm.add(
+          sm.mul(y, clippedLog(p)),
+          sm.mul(sm.scalar(1).sub(y), clippedLog(sm.scalar(1).sub(p)))
+        )
+      )
+    )
+}
+
+/** Ensures we have a finite loss near log(0), matches torch implementation */
+function clippedLog(x: sm.Tensor): sm.Tensor {
+  return sm.maximum(sm.log(x), sm.scalar(-100))
+}

--- a/shumai/loss/index.ts
+++ b/shumai/loss/index.ts
@@ -4,6 +4,16 @@ export * from './mse'
 export type LossFn = (a: sm.Tensor, b: sm.Tensor) => sm.Tensor
 
 /**
+ * Mean absolute error for regression
+ * Also known as L1-loss
+ *
+ * $$\frac{1}{n}\sum_{i=1}^{n}|y_{i}-\hat{y}_{i}|$$
+ */
+export function mae(): LossFn {
+  return (y, p) => sm.mean(sm.abs(sm.sub(y, p)))
+}
+
+/**
  * Cross-entropy loss for multi-class classification
  * Use with softmax on the final activation layer
  *

--- a/test/loss.test.ts
+++ b/test/loss.test.ts
@@ -2,7 +2,7 @@ import * as sm from '@shumai/shumai'
 import { describe, it } from 'bun:test'
 import { expectArraysClose } from './utils'
 
-describe('loss', () => {
+describe('mse', () => {
   it('should be near zero', () => {
     const a = sm.tensor(new Float32Array([1, 2, 3]))
     const b = sm.tensor(new Float32Array([1, 2, 3]))
@@ -16,3 +16,50 @@ describe('loss', () => {
     expectArraysClose(mse.toFloat32Array(), [18.666])
   })
 })
+
+describe('crossEntropy', () => {
+  it('zero loss', () => {
+    const a = tableToTensor([
+      [0, 1, 0],
+      [0, 0, 1]
+    ])
+    const b = tableToTensor([
+      [0, 1, 0],
+      [0, 0, 1]
+    ])
+    const loss = sm.loss.crossEntropy()
+    expectArraysClose(loss(a, b).toFloat32Array(), [0])
+  })
+
+  it('nonzero loss', () => {
+    const a = tableToTensor([
+      [0, 1, 0],
+      [0, 0, 1]
+    ])
+    const b = tableToTensor([
+      [0.05, 0.95, 0],
+      [0.1, 0.8, 0.1]
+    ])
+    const loss = sm.loss.crossEntropy()
+    expectArraysClose(loss(a, b).toFloat32Array(), [1.177])
+  })
+})
+
+describe('binaryCrossEntropy', () => {
+  it('zero loss', () => {
+    const a = sm.tensor(new Float32Array([0, 1, 0, 1]))
+    const b = sm.tensor(new Float32Array([0, 1, 0, 1]))
+    const loss = sm.loss.binaryCrossEntropy()
+    expectArraysClose(loss(a, b).toFloat32Array(), [0])
+  })
+
+  it('nonzero loss', () => {
+    const a = sm.tensor(new Float32Array([0, 1, 0, 1]))
+    const b = sm.tensor(new Float32Array([0.2, 0.9, 0.5, 0.4]))
+    const loss = sm.loss.binaryCrossEntropy()
+    expectArraysClose(loss(a, b).toFloat32Array(), [0.484486])
+  })
+})
+
+const tableToTensor = (table: number[][]): sm.Tensor =>
+  sm.tensor(new Float32Array(table.flat())).reshape([table.length, table[0].length])

--- a/test/loss.test.ts
+++ b/test/loss.test.ts
@@ -17,6 +17,23 @@ describe('mse', () => {
   })
 })
 
+describe('mae', () => {
+  it('should be near zero', () => {
+    const a = sm.tensor(new Float32Array([1, 2, 3]))
+    const b = sm.tensor(new Float32Array([1, 2, 3]))
+    const loss = sm.loss.mae()
+    const mae = loss(a, b)
+    expectArraysClose(mae.toFloat32Array(), [0])
+  })
+  it('nonzero loss', () => {
+    const a = sm.tensor(new Float32Array([1, 2, 3]))
+    const b = sm.tensor(new Float32Array([-1, -2, -3]))
+    const loss = sm.loss.mae()
+    const mae = loss(a, b)
+    expectArraysClose(mae.toFloat32Array(), [4])
+  })
+})
+
 describe('crossEntropy', () => {
   it('zero loss', () => {
     const a = tableToTensor([
@@ -30,7 +47,6 @@ describe('crossEntropy', () => {
     const loss = sm.loss.crossEntropy()
     expectArraysClose(loss(a, b).toFloat32Array(), [0])
   })
-
   it('nonzero loss', () => {
     const a = tableToTensor([
       [0, 1, 0],
@@ -52,7 +68,6 @@ describe('binaryCrossEntropy', () => {
     const loss = sm.loss.binaryCrossEntropy()
     expectArraysClose(loss(a, b).toFloat32Array(), [0])
   })
-
   it('nonzero loss', () => {
     const a = sm.tensor(new Float32Array([0, 1, 0, 1]))
     const b = sm.tensor(new Float32Array([0.2, 0.9, 0.5, 0.4]))


### PR DESCRIPTION
This PR adds some common loss functions to compliment the existing `mse` loss.

I have chosen to implement the loss functions as creator functions `(options) => (y, yhat) => number` to accommodate adding configuration options to these functions in the future.

For example, torch's [`cross_entropy`](https://pytorch.org/docs/stable/generated/torch.nn.functional.cross_entropy.html) function accepts `reduction: "mean" | "sum" | "none"` as a configuration option.
This could then be available to users as such:
```ts
// model.ts
export const loss = sm.loss.crossEntropy({ reduction: "mean" });
```

But if you have other plans I am more than happy to remove the pattern.