### PR TITLE
Resolve race condition with stats

### DIFF
--- a/shumai/stats/stats.ts
+++ b/shumai/stats/stats.ts
@@ -290,14 +290,21 @@ export class Stats {
   }
 
   async flush(): Promise<void> {
-    await Promise.all(this.#loggers.map(l => l.process({
-      stats: this,
-      ops: this.#statsByOp,
-      stacks: this.#statsByStack,
-      stackKeys: this.#stackKeys
-    })));
+    const promises = this.#loggers.map((l) =>
+      l
+        .process({
+          stats: this,
+          ops: this.#statsByOp,
+          stacks: this.#statsByStack,
+          stackKeys: this.#stackKeys
+        })
+        .catch((err) => void console.warn(err.message))
+    )
 
+    // do not wait before resetting to avoid race condition
     this.reset()
+
+    await Promise.all(promises)
   }
 
   private async log(info: StatInfo, stat: StatsEntry): Promise<void> {
@@ -344,7 +351,7 @@ export class Stats {
       this.#loggers.length &&
       performance.timeOrigin + performance.now() - this.#startTime >= this.#interval
     ) {
-      await this.flush();
+      this.flush()
     }
   }
 


### PR DESCRIPTION
This prevents stats from recursively spamming loggers while prior flushes are pending.