### PR TITLE
Use new CircleCI CUDA images, downgrade to medium GPU instance

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,8 +8,8 @@ version: 2.1
 
 gpu: &gpu
   machine:
-    image: ubuntu-2004-cuda-11.4:202110-01
-  resource_class: gpu.nvidia.large
+    image: linux-cuda-11:2023.02.1
+  resource_class: gpu.nvidia.medium
 
 orbs:
   node: circleci/node@5.0.2
@@ -207,29 +207,15 @@ jobs:
   test-arrayfire-gpu-linux:
     <<: *gpu
     steps:
+      - run:
+          name: "Use CUDA 11.4"
+          command: sudo update-alternatives --set cuda /usr/local/cuda-11.4
       - setup_arrayfire_apt
       - run:
-          # Using an older CUDA version to CircleCI's GPU executor CUDA driver versions being ancient
-          name: "Install ArrayFire CUDA backend with CUDA 10.2 runtime"
-          command: sudo apt install arrayfire-cuda3-cuda-10-2 arrayfire-cuda-dev
-      - run:
-          name: "Install CUDA Toolkit 10.2"
+          name: "Install ArrayFire 3.8.1 with CUDA 11.4"
           command: |
-            cd /tmp
-            wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/cuda-keyring_1.0-1_all.deb
-            sudo dpkg -i cuda-keyring_1.0-1_all.deb
-            sudo apt update
-            sudo apt install cuda-toolkit-10-2 libcudnn8-dev
-            sudo rm /usr/local/cuda # may point to other non-10.2 CUDA libs
-            sudo ln -s /usr/local/cuda-10.2 /usr/local/cuda
-            echo 'export PATH="/usr/local/cuda/bin:$PATH"' >> $BASH_ENV
-      - run:
-          name: "Install gcc 8"
-          # CUDA 10.2's nvcc won't work with gcc >= 9
-          command: |
-            sudo apt-get -y install gcc-8 g++-8
-            sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-8 8
-            sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-8 8
+            sudo apt install arrayfire-cmake=3.8.1-2 arrayfire-headers=3.8.1-2
+            sudo apt install arrayfire-cuda3-cuda-11-4=3.8.1-2 arrayfire-cuda3-dev=3.8.1-2
       - install_flashlight:
           arrayfire_backend: "CUDA"
           extra_flags: ""


### PR DESCRIPTION
See title. [Context here](https://discuss.circleci.com/t/cuda-11-8-gpu-cuda-image-any-plans/47240). We can use gcc 9 standard because CUDA 11's nvcc supports it

Test plan: CI